### PR TITLE
Unify ~from -> ~start

### DIFF
--- a/migration/migration.toml
+++ b/migration/migration.toml
@@ -27,11 +27,11 @@ rewrite="Array.getUnsafe"
 
 [array-a-sliceFrom]
 match="Js.Array2.sliceFrom(:[from])"
-rewrite="Array.sliceToEnd(~from=:[from])"
+rewrite="Array.sliceToEnd(~start=:[from])"
 
 [array-a-slice]
 match="Js.Array2.slice(~start=:[from], ~end_=:[to])"
-rewrite="Array.slice(~from=:[from], ~end=:[to])"
+rewrite="Array.slice(~start=:[from], ~end=:[to])"
 
 [array-z]
 match="Js.Array2"
@@ -166,7 +166,7 @@ rewrite="Array.forEachWithIndex"
 
 [belt-array-a-sliceToEnd]
 match="Belt.Array.sliceToEnd(:[from])"
-rewrite="Array.sliceToEnd(~from=:[from])"
+rewrite="Array.sliceToEnd(~start=:[from])"
 
 [belt-array-a-reduce]
 match="Belt.Array.reduce"

--- a/src/Core__Array.res
+++ b/src/Core__Array.res
@@ -62,7 +62,7 @@ let indexOfOpt = (arr, item) =>
   | -1 => None
   | index => Some(index)
   }
-@send external indexOfFrom: (array<'a>, 'a, ~from: int) => int = "indexOf"
+@send external indexOfFrom: (array<'a>, 'a, int) => int = "indexOf"
 
 @send external joinWith: (array<'a>, string) => string = "join"
 
@@ -72,10 +72,10 @@ let lastIndexOfOpt = (arr, item) =>
   | -1 => None
   | index => Some(index)
   }
-@send external lastIndexOfFrom: (array<'a>, 'a, ~from: int) => int = "lastIndexOf"
+@send external lastIndexOfFrom: (array<'a>, 'a, int) => int = "lastIndexOf"
 
-@send external slice: (array<'a>, ~from: int, ~end: int) => array<'a> = "slice"
-@send external sliceToEnd: (array<'a>, ~from: int) => array<'a> = "slice"
+@send external slice: (array<'a>, ~start: int, ~end: int) => array<'a> = "slice"
+@send external sliceToEnd: (array<'a>, ~start: int) => array<'a> = "slice"
 @send external copy: array<'a> => array<'a> = "slice"
 
 @send external toString: array<'a> => string = "toString"

--- a/src/Core__Array.resi
+++ b/src/Core__Array.resi
@@ -32,13 +32,13 @@ external spliceInPlace: (array<'a>, ~start: int, ~remove: int, ~insert: array<'a
 @send external includes: (array<'a>, 'a) => bool = "includes"
 @send external indexOf: (array<'a>, 'a) => int = "indexOf"
 let indexOfOpt: (array<'a>, 'a) => option<int>
-@send external indexOfFrom: (array<'a>, 'a, ~from: int) => int = "indexOf"
+@send external indexOfFrom: (array<'a>, 'a, int) => int = "indexOf"
 @send external joinWith: (array<'a>, string) => string = "join"
 @send external lastIndexOf: (array<'a>, 'a) => int = "lastIndexOf"
 let lastIndexOfOpt: (array<'a>, 'a) => option<int>
-@send external lastIndexOfFrom: (array<'a>, 'a, ~from: int) => int = "lastIndexOf"
-@send external slice: (array<'a>, ~from: int, ~end: int) => array<'a> = "slice"
-@send external sliceToEnd: (array<'a>, ~from: int) => array<'a> = "slice"
+@send external lastIndexOfFrom: (array<'a>, 'a, int) => int = "lastIndexOf"
+@send external slice: (array<'a>, ~start: int, ~end: int) => array<'a> = "slice"
+@send external sliceToEnd: (array<'a>, ~start: int) => array<'a> = "slice"
 @send external copy: array<'a> => array<'a> = "slice"
 @send external toString: array<'a> => string = "toString"
 @send external toLocaleString: array<'a> => string = "toLocaleString"

--- a/src/Core__String.res
+++ b/src/Core__String.res
@@ -17,10 +17,10 @@
 @variadic @send external concatMany: (string, array<string>) => string = "concat"
 
 @send external endsWith: (string, string) => bool = "endsWith"
-@send external endsWithFrom: (string, string, ~from: int) => bool = "endsWith"
+@send external endsWithFrom: (string, string, int) => bool = "endsWith"
 
 @send external includes: (string, string) => bool = "includes"
-@send external includesFrom: (string, string, ~from: int) => bool = "includes"
+@send external includesFrom: (string, string, int) => bool = "includes"
 
 @send external indexOf: (string, string) => int = "indexOf"
 let indexOfOpt = (s, search) =>
@@ -28,7 +28,7 @@ let indexOfOpt = (s, search) =>
   | -1 => None
   | index => Some(index)
   }
-@send external indexOfFrom: (string, string, ~from: int) => int = "indexOf"
+@send external indexOfFrom: (string, string, int) => int = "indexOf"
 
 @send external lastIndexOf: (string, string) => int = "lastIndexOf"
 let lastIndexOfOpt = (s, search) =>
@@ -36,7 +36,7 @@ let lastIndexOfOpt = (s, search) =>
   | -1 => None
   | index => Some(index)
   }
-@send external lastIndexOfFrom: (string, string, ~from: int) => int = "lastIndexOf"
+@send external lastIndexOfFrom: (string, string, int) => int = "lastIndexOf"
 
 @return(nullable) @send
 external match: (string, Core__RegExp.t) => option<Core__RegExp.Result.t> = "match"
@@ -109,7 +109,7 @@ external splitByRegExpAtMost: (string, Core__RegExp.t, ~limit: int) => array<opt
   "split"
 
 @send external startsWith: (string, string) => bool = "startsWith"
-@send external startsWithFrom: (string, string, ~from: int) => bool = "startsWith"
+@send external startsWithFrom: (string, string, int) => bool = "startsWith"
 
 @send external substring: (string, ~start: int, ~end: int) => string = "substring"
 @send external substringToEnd: (string, ~start: int) => string = "substring"

--- a/src/typed-arrays/Core__TypedArray.res
+++ b/src/typed-arrays/Core__TypedArray.res
@@ -8,7 +8,7 @@ type t<'a>
 @get external byteOffset: t<'a> => int = "byteOffset"
 
 @send external setArray: (t<'a>, array<'a>) => unit = "set"
-@send external setArrayFrom: (t<'a>, array<'a>, ~from: int) => unit = "set"
+@send external setArrayFrom: (t<'a>, array<'a>, int) => unit = "set"
 
 @get external length: t<'a> => int = "length"
 
@@ -27,19 +27,19 @@ external copyWithin: (t<'a>, ~target: int, ~start: int, ~end: int) => array<'a> 
 @send external includes: (t<'a>, 'a) => bool = "includes"
 
 @send external indexOf: (t<'a>, 'a) => int = "indexOf"
-@send external indexOfFrom: (t<'a>, 'a, ~from: int) => int = "indexOf"
+@send external indexOfFrom: (t<'a>, 'a, int) => int = "indexOf"
 
 @send external joinWith: (t<'a>, string) => string = "join"
 
 @send external lastIndexOf: (t<'a>, 'a) => int = "lastIndexOf"
-@send external lastIndexOfFrom: (t<'a>, 'a, ~from: int) => int = "lastIndexOf"
+@send external lastIndexOfFrom: (t<'a>, 'a, int) => int = "lastIndexOf"
 
-@send external slice: (t<'a>, ~from: int, ~end: int) => t<'a> = "slice"
-@send external sliceToEnd: (t<'a>, ~from: int) => t<'a> = "slice"
+@send external slice: (t<'a>, ~start: int, ~end: int) => t<'a> = "slice"
+@send external sliceToEnd: (t<'a>, ~start: int) => t<'a> = "slice"
 @send external copy: t<'a> => t<'a> = "slice"
 
-@send external subarray: (t<'a>, ~from: int, ~end: int) => t<'a> = "subarray"
-@send external subarrayToEnd: (t<'a>, ~from: int) => t<'a> = "subarray"
+@send external subarray: (t<'a>, ~start: int, ~end: int) => t<'a> = "subarray"
+@send external subarrayToEnd: (t<'a>, ~start: int) => t<'a> = "subarray"
 
 @send external toString: t<'a> => string = "toString"
 @send external toLocaleString: t<'a> => string = "toLocaleString"

--- a/test/Test.res
+++ b/test/Test.res
@@ -21,7 +21,7 @@ let cleanUpStackTrace = stack => {
     if i >= Array.length(lines) {
       lines
     } else if Array.getUnsafe(lines, i)->String.indexOf(" (internal/") >= 0 {
-      lines->Array.slice(~from=0, ~end=i)
+      lines->Array.slice(~start=0, ~end=i)
     } else {
       removeInternalLines(lines, i + 1)
     }
@@ -30,7 +30,7 @@ let cleanUpStackTrace = stack => {
   stack
   ->String.split("\n")
   // first line is "Error ...". Second line is this frame's stack trace. Ignore the 2
-  ->Array.sliceToEnd(~from=2)
+  ->Array.sliceToEnd(~start=2)
   ->removeInternalLines(0)
   // stack is indented 4 spaces. Remove 2
   ->Array.map(line => line->String.sliceToEnd(~start=2))


### PR DESCRIPTION
Usage of `~from` vs. `~start` was inconsistent, unifying to `~start`.