### PR TITLE
Fix incorrect type signatures in Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Change `Iterator` bindings to have the same shape as `AsyncIterator` for consistency. https://github.com/rescript-association/rescript-core/pull/34
 - Add `Iterator.toArray` binding for turning an iterator into an array. https://github.com/rescript-association/rescript-core/pull/34
 - Add `Array.at` binding for returning an array item by its index. https://github.com/rescript-association/rescript-core/pull/48
+- Fixed type signatures of `Array.fromArrayLikeWithMap` and `Array.fromIteratorWithMap`. https://github.com/rescript-association/rescript-core/pull/50
 
 ### Documentation
 

--- a/src/Core__Array.res
+++ b/src/Core__Array.res
@@ -9,7 +9,7 @@ external setUnsafe: (array<'a>, int, 'a) => unit = "%array_unsafe_set"
 external fromArrayLikeWithMap: (Js.Array2.array_like<'a>, 'a => 'b) => array<'b> = "Array.from"
 
 @val external fromIterator: Core__Iterator.t<'a> => array<'a> = "Array.from"
-@val external fromIteratorWithMap: (Core__Iterator.t<'a>, 'a => 'c) => array<'a> = "Array.from"
+@val external fromIteratorWithMap: (Core__Iterator.t<'a>, 'a => 'b) => array<'b> = "Array.from"
 
 @val external isArray: 'a => bool = "Array.isArray"
 

--- a/src/Core__Array.res
+++ b/src/Core__Array.res
@@ -6,7 +6,7 @@ external setUnsafe: (array<'a>, int, 'a) => unit = "%array_unsafe_set"
 
 @val external fromArrayLike: Js.Array2.array_like<'a> => array<'a> = "Array.from"
 @val
-external fromArrayLikeWithMap: (Js.Array2.array_like<'a>, 'a => 'b) => array<'a> = "Array.from"
+external fromArrayLikeWithMap: (Js.Array2.array_like<'a>, 'a => 'b) => array<'b> = "Array.from"
 
 @val external fromIterator: Core__Iterator.t<'a> => array<'a> = "Array.from"
 @val external fromIteratorWithMap: (Core__Iterator.t<'a>, 'a => 'c) => array<'a> = "Array.from"

--- a/src/Core__Array.resi
+++ b/src/Core__Array.resi
@@ -2,7 +2,7 @@
 @val external fromWithMap: ('a, 'b => 'c) => array<'c> = "Array.from"
 @val external fromArrayLike: Js.Array2.array_like<'a> => array<'a> = "Array.from"
 @val
-external fromArrayLikeWithMap: (Js.Array2.array_like<'a>, 'a => 'b) => array<'a> = "Array.from"
+external fromArrayLikeWithMap: (Js.Array2.array_like<'a>, 'a => 'b) => array<'b> = "Array.from"
 @val external fromIterator: Core__Iterator.t<'a> => array<'a> = "Array.from"
 @val external fromIteratorWithMap: (Core__Iterator.t<'a>, 'a => 'c) => array<'a> = "Array.from"
 @val external isArray: 'a => bool = "Array.isArray"

--- a/src/Core__Array.resi
+++ b/src/Core__Array.resi
@@ -4,7 +4,7 @@
 @val
 external fromArrayLikeWithMap: (Js.Array2.array_like<'a>, 'a => 'b) => array<'b> = "Array.from"
 @val external fromIterator: Core__Iterator.t<'a> => array<'a> = "Array.from"
-@val external fromIteratorWithMap: (Core__Iterator.t<'a>, 'a => 'c) => array<'a> = "Array.from"
+@val external fromIteratorWithMap: (Core__Iterator.t<'a>, 'a => 'b) => array<'b> = "Array.from"
 @val external isArray: 'a => bool = "Array.isArray"
 @get external length: array<'a> => int = "length"
 @send external copyAllWithin: (array<'a>, ~target: int) => array<'a> = "copyWithin"


### PR DESCRIPTION
Unless I'm misunderstanding something, these type signatures shouldn't be unsoundly typed, that is, the return type shouldn't be independent of the input argument types.