### PR TITLE
chore(test): fix undefined __dirname in node 19

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 19.x]
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [16.x, 18.x, 19.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/test/Test.mjs
+++ b/test/Test.mjs
@@ -5,9 +5,7 @@ import * as Path from "path";
 import * as Curry from "rescript/lib/es6/curry.js";
 import * as CodeFrame from "@babel/code-frame";
 
-var dirname = typeof __dirname === "undefined" ? undefined : __dirname;
-
-var dirname$1 = dirname !== undefined ? dirname : "";
+var dirname = (new URL('.', import.meta.url).pathname);
 
 function cleanUpStackTrace(stack) {
   var removeInternalLines = function (lines, _i) {
@@ -35,7 +33,7 @@ function run(loc, left, comparator, right) {
   var match = loc[0];
   var line = match[1];
   var file = match[0];
-  var fileContent = Fs.readFileSync(Path.join(dirname$1, file), {
+  var fileContent = Fs.readFileSync(Path.join(dirname, file), {
         encoding: "utf-8"
       });
   var left$1 = JSON.stringify(left);
@@ -55,7 +53,7 @@ function run(loc, left, comparator, right) {
 }
 
 export {
-  dirname$1 as dirname,
+  dirname ,
   cleanUpStackTrace ,
   run ,
 }

--- a/test/Test.res
+++ b/test/Test.res
@@ -9,10 +9,7 @@ external codeFrameColumns: (string, {..}, {..}) => string = "codeFrameColumns"
 @module("fs") @val external readFileSync: (string, {..}) => string = "readFileSync"
 @module("path") @val external join: (string, string) => string = "join"
 
-let dirname = switch %external(__dirname) {
-| None => ""
-| Some(dirname) => dirname
-}
+let dirname = %raw("new URL('.', import.meta.url).pathname")
 
 let cleanUpStackTrace = stack => {
   // Stack format: https://nodejs.org/api/errors.html#errors_error_stack


### PR DESCRIPTION
`__dirname` is apparently in es modules as of node 19. This fixes that by using `import.meta.url` instead.

Also adds current and latest LTS node versions (19 and 18 respectively) to the CI matrix.