### PR TITLE
refactor: WithDefault -> Or

### DIFF
--- a/src/Core__Null.mjs
+++ b/src/Core__Null.mjs
@@ -20,7 +20,7 @@ function compare(a, b, cmp) {
   return Core__Option.compare(a === null ? undefined : Caml_option.some(a), b === null ? undefined : Caml_option.some(b), cmp);
 }
 
-function getWithDefault(value, $$default) {
+function getOr(value, $$default) {
   if (value !== null) {
     return value;
   } else {
@@ -47,7 +47,7 @@ function map(value, f) {
   }
 }
 
-function mapWithDefault(value, $$default, f) {
+function mapOr(value, $$default, f) {
   if (value !== null) {
     return Curry._1(f, value);
   } else {
@@ -63,13 +63,19 @@ function flatMap(value, f) {
   }
 }
 
+var getWithDefault = getOr;
+
+var mapWithDefault = mapOr;
+
 export {
   equal ,
   compare ,
   fromOption ,
+  getOr ,
   getWithDefault ,
   getExn ,
   map ,
+  mapOr ,
   mapWithDefault ,
   flatMap ,
 }

--- a/src/Core__Null.res
+++ b/src/Core__Null.res
@@ -18,11 +18,13 @@ let equal = (a, b, eq) => Core__Option.equal(a->toOption, b->toOption, eq)
 
 let compare = (a, b, cmp) => Core__Option.compare(a->toOption, b->toOption, cmp)
 
-let getWithDefault = (value, default) =>
+let getOr = (value, default) =>
   switch value->toOption {
   | Some(x) => x
   | None => default
   }
+
+let getWithDefault = getOr
 
 let getExn: t<'a> => 'a = value =>
   switch value->toOption {
@@ -38,11 +40,13 @@ let map = (value, f) =>
   | None => null
   }
 
-let mapWithDefault = (value, default, f) =>
+let mapOr = (value, default, f) =>
   switch value->toOption {
   | Some(x) => f(x)
   | None => default
   }
+
+let mapWithDefault = mapOr
 
 let flatMap = (value, f) =>
   switch value->toOption {

--- a/src/Core__Null.resi
+++ b/src/Core__Null.resi
@@ -77,22 +77,25 @@ Console.log(asNull == null) // Logs `true` to the console.
 let fromOption: option<'a> => t<'a>
 
 /**
-`getWithDefault(value, default)` returns `value` if not `null`, otherwise return
+`getOr(value, default)` returns `value` if not `null`, otherwise return
 `default`.
 
 ## Examples
 
 ```rescript
-Null.getWithDefault(null, "Banana") // Banana
-Null.getWithDefault(Nulalble.make("Apple"), "Banana") // Apple
+Null.getOr(null, "Banana") // Banana
+Null.getOr(Nulalble.make("Apple"), "Banana") // Apple
 
 let greet = (firstName: option<string>) =>
-  "Greetings " ++ firstName->Null.getWithDefault("Anonymous")
+  "Greetings " ++ firstName->Null.getOr("Anonymous")
 
 Null.make("Jane")->greet // "Greetings Jane"
 null->greet // "Greetings Anonymous"
 ```
 */
+let getOr: (t<'a>, 'a) => 'a
+
+@deprecated("Use getOr instead")
 let getWithDefault: (t<'a>, 'a) => 'a
 
 /**
@@ -139,19 +142,22 @@ Null.map(null, x => x * x) // null
 let map: (t<'a>, 'a => 'b) => t<'b>
 
 /**
-`mapWithDefault(value, default, f)` returns `f(value)` if `value` is not `null`,
+`mapOr(value, default, f)` returns `f(value)` if `value` is not `null`,
 otherwise returns `default`.
 
 ## Examples
 
 ```rescript
 let someValue = Null.make(3)
-someValue->Null.mapWithDefault(0, x => x + 5) // 8
+someValue->Null.mapOr(0, x => x + 5) // 8
 
 let noneValue = null
-noneValue->Null.mapWithDefault(0, x => x + 5) // 0
+noneValue->Null.mapOr(0, x => x + 5) // 0
 ```
 */
+let mapOr: (t<'a>, 'b, 'a => 'b) => 'b
+
+@deprecated("Use mapOr instead")
 let mapWithDefault: (t<'a>, 'b, 'a => 'b) => 'b
 
 /**

--- a/src/Core__Nullable.mjs
+++ b/src/Core__Nullable.mjs
@@ -19,7 +19,7 @@ function compare(a, b, cmp) {
   return Core__Option.compare((a == null) ? undefined : Caml_option.some(a), (b == null) ? undefined : Caml_option.some(b), cmp);
 }
 
-function getWithDefault(value, $$default) {
+function getOr(value, $$default) {
   if (value == null) {
     return $$default;
   } else {
@@ -46,7 +46,7 @@ function map(value, f) {
   }
 }
 
-function mapWithDefault(value, $$default, f) {
+function mapOr(value, $$default, f) {
   if (value == null) {
     return $$default;
   } else {
@@ -62,13 +62,19 @@ function flatMap(value, f) {
   }
 }
 
+var getWithDefault = getOr;
+
+var mapWithDefault = mapOr;
+
 export {
   equal ,
   compare ,
   fromOption ,
+  getOr ,
   getWithDefault ,
   getExn ,
   map ,
+  mapOr ,
   mapWithDefault ,
   flatMap ,
 }

--- a/src/Core__Nullable.res
+++ b/src/Core__Nullable.res
@@ -18,11 +18,13 @@ let equal = (a, b, eq) => Core__Option.equal(a->toOption, b->toOption, eq)
 
 let compare = (a, b, cmp) => Core__Option.compare(a->toOption, b->toOption, cmp)
 
-let getWithDefault = (value, default) =>
+let getOr = (value, default) =>
   switch value->toOption {
   | Some(x) => x
   | None => default
   }
+
+let getWithDefault = getOr
 
 let getExn: t<'a> => 'a = value =>
   switch value->toOption {
@@ -38,11 +40,13 @@ let map = (value, f) =>
   | None => Obj.magic(value)
   }
 
-let mapWithDefault = (value, default, f) =>
+let mapOr = (value, default, f) =>
   switch value->toOption {
   | Some(x) => f(x)
   | None => default
   }
+
+let mapWithDefault = mapOr
 
 let flatMap = (value, f) =>
   switch value->toOption {

--- a/src/Core__Nullable.resi
+++ b/src/Core__Nullable.resi
@@ -87,22 +87,25 @@ let asNullable = optString->Nullable.fromOption // Nullable.t<string>
 let fromOption: option<'a> => t<'a>
 
 /**
-`getWithDefault(value, default)` returns `value` if not `null` or `undefined`,
+`getOr(value, default)` returns `value` if not `null` or `undefined`,
 otherwise return `default`.
 
 ## Examples
 
 ```rescript
-Nullable.getWithDefault(Nullable.null, "Banana") // Banana
-Nullable.getWithDefault(Nulalble.make("Apple"), "Banana") // Apple
+Nullable.getOr(Nullable.null, "Banana") // Banana
+Nullable.getOr(Nulalble.make("Apple"), "Banana") // Apple
 
 let greet = (firstName: option<string>) =>
-  "Greetings " ++ firstName->Nullable.getWithDefault("Anonymous")
+  "Greetings " ++ firstName->Nullable.getOr("Anonymous")
 
 Nullable.make("Jane")->greet // "Greetings Jane"
 Nullable.null->greet // "Greetings Anonymous"
 ```
 */
+let getOr: (t<'a>, 'a) => 'a
+
+@deprecated("Use getOr instead")
 let getWithDefault: (t<'a>, 'a) => 'a
 
 /**
@@ -149,19 +152,22 @@ Nullable.map(undefined, x => x * x) // undefined
 let map: (t<'a>, 'a => 'b) => t<'b>
 
 /**
-`mapWithDefault(value, default, f)` returns `f(value)` if `value` is not `null`
+`mapOr(value, default, f)` returns `f(value)` if `value` is not `null`
 or `undefined`, otherwise returns `default`.
 
 ## Examples
 
 ```rescript
 let someValue = Nullable.make(3)
-someValue->Nullable.mapWithDefault(0, x => x + 5) // 8
+someValue->Nullable.mapOr(0, x => x + 5) // 8
 
 let noneValue = Nullable.null
-noneValue->Nullable.mapWithDefault(0, x => x + 5) // 0
+noneValue->Nullable.mapOr(0, x => x + 5) // 0
 ```
 */
+let mapOr: (t<'a>, 'b, 'a => 'b) => 'b
+
+@deprecated("Use mapOr instead")
 let mapWithDefault: (t<'a>, 'b, 'a => 'b) => 'b
 
 /**

--- a/src/Core__Option.mjs
+++ b/src/Core__Option.mjs
@@ -29,7 +29,7 @@ function getExn(x) {
       };
 }
 
-function mapWithDefault(opt, $$default, f) {
+function mapOr(opt, $$default, f) {
   var f$1 = Curry.__1(f);
   if (opt !== undefined) {
     return f$1(Caml_option.valFromOption(opt));
@@ -54,7 +54,7 @@ function flatMap(opt, f) {
   
 }
 
-function getWithDefault(opt, $$default) {
+function getOr(opt, $$default) {
   if (opt !== undefined) {
     return Caml_option.valFromOption(opt);
   } else {
@@ -104,13 +104,19 @@ function compare(a, b, cmp) {
   }
 }
 
+var mapWithDefault = mapOr;
+
+var getWithDefault = getOr;
+
 export {
   filter ,
   forEach ,
   getExn ,
+  mapOr ,
   mapWithDefault ,
   map ,
   flatMap ,
+  getOr ,
   getWithDefault ,
   orElse ,
   isSome ,

--- a/src/Core__Option.res
+++ b/src/Core__Option.res
@@ -46,13 +46,15 @@ let getExn = x =>
 
 external getUnsafe: option<'a> => 'a = "%identity"
 
-let mapWithDefaultU = (opt, default, f) =>
+let mapOrU = (opt, default, f) =>
   switch opt {
   | Some(x) => f(. x)
   | None => default
   }
 
-let mapWithDefault = (opt, default, f) => mapWithDefaultU(opt, default, (. x) => f(x))
+let mapOr = (opt, default, f) => mapOrU(opt, default, (. x) => f(x))
+
+let mapWithDefault = mapOr
 
 let mapU = (opt, f) =>
   switch opt {
@@ -70,11 +72,13 @@ let flatMapU = (opt, f) =>
 
 let flatMap = (opt, f) => flatMapU(opt, (. x) => f(x))
 
-let getWithDefault = (opt, default) =>
+let getOr = (opt, default) =>
   switch opt {
   | Some(x) => x
   | None => default
   }
+
+let getWithDefault = getOr
 
 let orElse = (opt, other) =>
   switch opt {

--- a/src/Core__Option.resi
+++ b/src/Core__Option.resi
@@ -96,18 +96,21 @@ Option.getUnsafe(None: option<int>) // Returns `undefined`, which is not a valid
 external getUnsafe: option<'a> => 'a = "%identity"
 
 /**
-`mapWithDefault(opt, default, f)` returns `f(value)` if `opt` is `Some(value)`, otherwise `default`.
+`mapOr(opt, default, f)` returns `f(value)` if `opt` is `Some(value)`, otherwise `default`.
 
 ## Examples
 
 ```rescript
 let someValue = Some(3)
-someValue->Option.mapWithDefault(0, x => x + 5) // 8
+someValue->Option.mapOr(0, x => x + 5) // 8
 
 let noneValue = None
-noneValue->Option.mapWithDefault(0, x => x + 5) // 0
+noneValue->Option.mapOr(0, x => x + 5) // 0
 ```
 */
+let mapOr: (option<'a>, 'b, 'a => 'b) => 'b
+
+@deprecated("Use mapOr instead")
 let mapWithDefault: (option<'a>, 'b, 'a => 'b) => 'b
 
 /**
@@ -143,21 +146,24 @@ Option.flatMap(None, addIfAboveOne) // None
 let flatMap: (option<'a>, 'a => option<'b>) => option<'b>
 
 /**
-`getWithDefault(opt, default)` returns `value` if `opt` is `Some(value)`, otherwise `default`.
+`getOr(opt, default)` returns `value` if `opt` is `Some(value)`, otherwise `default`.
 
 ## Examples
 
 ```rescript
-Option.getWithDefault(None, "Banana") // Banana
-Option.getWithDefault(Some("Apple"), "Banana") // Apple
+Option.getOr(None, "Banana") // Banana
+Option.getOr(Some("Apple"), "Banana") // Apple
 
 let greet = (firstName: option<string>) =>
-  "Greetings " ++ firstName->Option.getWithDefault("Anonymous")
+  "Greetings " ++ firstName->Option.getOr("Anonymous")
 
 Some("Jane")->greet // "Greetings Jane"
 None->greet // "Greetings Anonymous"
 ```
 */
+let getOr: (option<'a>, 'a) => 'a
+
+@deprecated("Use getOr instead")
 let getWithDefault: (option<'a>, 'a) => 'a
 
 /**

--- a/src/Core__Result.mjs
+++ b/src/Core__Result.mjs
@@ -12,7 +12,7 @@ function getExn(x) {
       };
 }
 
-function mapWithDefault(opt, $$default, f) {
+function mapOr(opt, $$default, f) {
   var f$1 = Curry.__1(f);
   if (opt.TAG === /* Ok */0) {
     return f$1(opt._0);
@@ -48,7 +48,7 @@ function flatMap(opt, f) {
   }
 }
 
-function getWithDefault(opt, $$default) {
+function getOr(opt, $$default) {
   if (opt.TAG === /* Ok */0) {
     return opt._0;
   } else {
@@ -118,11 +118,17 @@ function mapError(r, f) {
   }
 }
 
+var mapWithDefault = mapOr;
+
+var getWithDefault = getOr;
+
 export {
   getExn ,
+  mapOr ,
   mapWithDefault ,
   map ,
   flatMap ,
+  getOr ,
   getWithDefault ,
   isOk ,
   isError ,

--- a/src/Core__Result.res
+++ b/src/Core__Result.res
@@ -30,13 +30,15 @@ let getExn = x =>
   | Error(_) => raise(Not_found)
   }
 
-let mapWithDefaultU = (opt, default, f) =>
+let mapOrU = (opt, default, f) =>
   switch opt {
   | Ok(x) => f(. x)
   | Error(_) => default
   }
 
-let mapWithDefault = (opt, default, f) => mapWithDefaultU(opt, default, (. x) => f(x))
+let mapOr = (opt, default, f) => mapOrU(opt, default, (. x) => f(x))
+
+let mapWithDefault = mapOr
 
 let mapU = (opt, f) =>
   switch opt {
@@ -54,11 +56,13 @@ let flatMapU = (opt, f) =>
 
 let flatMap = (opt, f) => flatMapU(opt, (. x) => f(x))
 
-let getWithDefault = (opt, default) =>
+let getOr = (opt, default) =>
   switch opt {
   | Ok(x) => x
   | Error(_) => default
   }
+
+let getWithDefault = getOr
 
 let isOk = x =>
   switch x {

--- a/src/Core__Result.resi
+++ b/src/Core__Result.resi
@@ -59,17 +59,20 @@ type t<'a, 'b> = result<'a, 'b> = Ok('a) | Error('b)
 let getExn: t<'a, 'b> => 'a
 
 /**
-  `mapWithDefault(res, default, f)`: When res is `Ok(n)`, returns `f(n)`,
+  `mapOr(res, default, f)`: When res is `Ok(n)`, returns `f(n)`,
   otherwise `default`.
 
   ```res example
   let ok = Result.Ok(42)
-  Result.mapWithDefault(ok, 0, (x) => x / 2) == 21
+  Result.mapOr(ok, 0, (x) => x / 2) == 21
 
   let error = Result.Error("Invalid data")
-  Result.mapWithDefault(error, 0, (x) => x / 2) == 0
+  Result.mapOr(error, 0, (x) => x / 2) == 0
   ```
 */
+let mapOr: (t<'a, 'c>, 'b, 'a => 'b) => 'b
+
+@deprecated("Use mapOr instead")
 let mapWithDefault: (t<'a, 'c>, 'b, 'a => 'b) => 'b
 
 /**
@@ -110,15 +113,18 @@ let map: (t<'a, 'c>, 'a => 'b) => t<'b, 'c>
 let flatMap: (t<'a, 'c>, 'a => t<'b, 'c>) => t<'b, 'c>
 
 /**
-  `getWithDefault(res, defaultValue)`: If `res` is `Ok(n)`, returns `n`,
+  `getOr(res, defaultValue)`: If `res` is `Ok(n)`, returns `n`,
   otherwise `default`
 
   ```res example
-  Result.getWithDefault(Ok(42), 0) == 42
+  Result.getOr(Ok(42), 0) == 42
 
-  Result.getWithDefault(Error("Invalid Data"), 0) == 0
+  Result.getOr(Error("Invalid Data"), 0) == 0
   ```
 */
+let getOr: (t<'a, 'b>, 'a) => 'a
+
+@deprecated("Use getOr instead")
 let getWithDefault: (t<'a, 'b>, 'a) => 'a
 
 /**

--- a/test/ObjectTests.mjs
+++ b/test/ObjectTests.mjs
@@ -555,7 +555,7 @@ runGetTest({
                 };
         }),
       get: (function (i) {
-          return Core__Option.getWithDefault(Core__Option.map(i["a"], (function (i) {
+          return Core__Option.getOr(Core__Option.map(i["a"], (function (i) {
                             return i.concat([
                                         4,
                                         5

--- a/test/ObjectTests.res
+++ b/test/ObjectTests.res
@@ -127,7 +127,7 @@ let runGetTest = i =>
 {
   title: "prop exists and is an array, can get it",
   source: () => {"a": [1, 2, 3]},
-  get: i => i->Object.get("a")->Option.map(i => i->Array.concat([4, 5]))->Option.getWithDefault([]),
+  get: i => i->Object.get("a")->Option.map(i => i->Array.concat([4, 5]))->Option.getOr([]),
   expected: [1, 2, 3, 4, 5],
 }->runGetTest
 


### PR DESCRIPTION
Renames `mapWithDefault` to`mapOr` and `getWithDefault` to `getOr` across all modules.

I expect this to be a bit controversial, so I suggest we do a vote on this. :+1: if you're for the change, :-1: if you're against.