### PR TITLE
switch global null to come from Nullable module and not Null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Remove `reduceReverse` in favor of `reduceRight`. https://github.com/rescript-association/rescript-core/pull/49
 - Fixed type signatures of `reduce` and `reduceWithIndex`. https://github.com/rescript-association/rescript-core/pull/49
 - Add `panic`/`Error.panic`. https://github.com/rescript-association/rescript-core/pull/72
+- The globally available `null` value now originates from `Nullable` and not `Null`, just like the globally available `undefined` value does. https://github.com/rescript-association/rescript-core/pull/88
 
 ### Documentation
 

--- a/src/RescriptCore.res
+++ b/src/RescriptCore.res
@@ -47,7 +47,7 @@ module Intl = Core__Intl
 @val external document: Dom.document = "document"
 @val external globalThis: {..} = "globalThis"
 
-external null: Core__Null.t<'a> = "#null"
+external null: Core__Nullable.t<'a> = "#null"
 external undefined: Core__Nullable.t<'a> = "#undefined"
 external typeof: 'a => Core__Type.t = "#typeof"
 


### PR DESCRIPTION
This changes the globally available `null` value to originate from `Nullable` rather than `Null`. Makes sense imo given that global `null` and `undefined` now originate from the same module.

It also makes working with domRefs in React more natural, allowing you to write `null` directly instead of `Nullable.null`:
```rescript
@react.component
let make = () => {
  let divRef = React.useRef(null)
  <div ref={divRef->ReactDOM.Ref.domRef}> {"Hello"->React.string} </div>
}
```

(side note - would be cool to get completion for `ReactDOM.Ref.*` in the scenario below. Might be able to work that into the editor tooling)

Thoughts? cc @cknitt @glennsl 