### PR TITLE
Remove deprecated j` string interpolation

### DIFF
--- a/src/Core__Error.mjs
+++ b/src/Core__Error.mjs
@@ -14,7 +14,7 @@ var $$TypeError = {};
 var $$URIError = {};
 
 function panic(msg) {
-  throw new Error("Panic! " + msg);
+  throw new Error("Panic! " + msg + "");
 }
 
 export {

--- a/src/Core__Error.res
+++ b/src/Core__Error.res
@@ -36,4 +36,4 @@ module URIError = {
 
 external raise: t => 'a = "%raise"
 
-let panic = msg => make(j`Panic! $msg`)->raise
+let panic = msg => make(`Panic! ${msg}`)->raise

--- a/test/Test.mjs
+++ b/test/Test.mjs
@@ -58,7 +58,7 @@ function run(loc, left, comparator, right) {
       }, {
         highlightCode: true
       });
-  var errorMessage = "\n  \u001b[31mTest Failure!\n  \u001b[36m" + file + "\u001b[0m:\u001b[2m" + line + "\n" + codeFrame + "\n  \u001b[39mLeft: \u001b[31m" + left$1 + "\n  \u001b[39mRight: \u001b[31m" + right$1 + "\u001b[0m\n";
+  var errorMessage = "\n  \u001b[31mTest Failure!\n  \u001b[36m" + file + "\u001b[0m:\u001b[2m" + line.toString() + "\n" + codeFrame + "\n  \u001b[39mLeft: \u001b[31m" + left$1 + "\n  \u001b[39mRight: \u001b[31m" + right$1 + "\u001b[0m\n";
   console.log(errorMessage);
   var obj = {};
   Error.captureStackTrace(obj);

--- a/test/Test.res
+++ b/test/Test.res
@@ -53,12 +53,12 @@ let run = (loc, left, comparator, right) => {
       {"start": {"line": line}},
       {"highlightCode": true},
     )
-    let errorMessage = j`
+    let errorMessage = `
   \u001b[31mTest Failure!
-  \u001b[36m$file\u001b[0m:\u001b[2m$line
-$codeFrame
-  \u001b[39mLeft: \u001b[31m$left
-  \u001b[39mRight: \u001b[31m$right\u001b[0m
+  \u001b[36m${file}\u001b[0m:\u001b[2m${line->Core__Int.toString}
+${codeFrame}
+  \u001b[39mLeft: \u001b[31m${left}
+  \u001b[39mRight: \u001b[31m${right}\u001b[0m
 `
     Console.log(errorMessage)
     // API: https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt


### PR DESCRIPTION
Get rid of "j" string interpolation that is deprecated in 10.1.4 and removed in 11.0.
(Otherwise Core will not build with the latest master of the compiler.)