### PR TITLE
Object.keysToArray documentation

### DIFF
--- a/src/Core__Object.res
+++ b/src/Core__Object.res
@@ -19,17 +19,16 @@
 @set_index external setSymbol: ({..}, Core__Symbol.t, 'a) => unit = ""
 
 /**
-`keysToArray` returns an array of an object's own enumerable string-keyed property names. 
+`keysToArray` returns an array of an object's own enumerable string-keyed property names. See [ECMAScript Language Specification](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.keys) 
+or [Object.keys on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys).
 
 ## Examples
 
 ```rescript
 {"a": 1, "b": 2}->Object.keysToArray // ["a", "b"]
-{"a": None}->Object.keysToArray // ["a"]Object.empty()->Object.keysToArray // []
+{"a": None}->Object.keysToArray // ["a"]
+Object.empty()->Object.keysToArray // []
 ```
-## Specifications
-- [ECMAScript Language Specification](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.keys)
-- [Object.keys on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys)
 */
 @val
 external keysToArray: {..} => array<string> = "Object.keys"

--- a/src/Core__Object.res
+++ b/src/Core__Object.res
@@ -25,8 +25,7 @@
 
 ```rescript
 {"a": 1, "b": 2}->Object.keysToArray // ["a", "b"]
-{"a": undefined}->Object.keysToArray // ["a"]
-Object.empty()->Object.keysToArray // []
+{"a": None}->Object.keysToArray // ["a"]Object.empty()->Object.keysToArray // []
 ```
 ## Specifications
 - [ECMAScript Language Specification](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.keys)

--- a/src/Core__Object.res
+++ b/src/Core__Object.res
@@ -18,7 +18,22 @@
 @set_index external set: ({..}, string, 'a) => unit = ""
 @set_index external setSymbol: ({..}, Core__Symbol.t, 'a) => unit = ""
 
-@val external keysToArray: {..} => array<string> = "Object.keys"
+/**
+`keysToArray` returns an array of an object's own enumerable string-keyed property names. 
+
+## Examples
+
+```rescript
+{"a": 1, "b": 2}->Object.keysToArray // ["a", "b"]
+{"a": undefined}->Object.keysToArray // ["a"]
+Object.empty()->Object.keysToArray // []
+```
+## Specifications
+- [ECMAScript Language Specification](https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.keys)
+- [Object.keys on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys)
+*/
+@val
+external keysToArray: {..} => array<string> = "Object.keys"
 
 @val external hasOwnProperty: ({..}, string) => bool = "Object.prototype.hasOwnProperty.call"
 


### PR DESCRIPTION
Object.keysToArray documentation. Why not just call this "keys"? Shorter and matches Javascript. I see a few places in the code with `keysToArray` - should change it everywhere. Map just uses `keys` and `values`.