### PR TITLE
Error.raiseAny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### API changes
 
 - Add `Result.forEach` https://github.com/rescript-association/rescript-core/pull/116
+- Add `Error.raiseAny` https://github.com/rescript-association/rescript-core/pull/120
 
 ## 0.2.0
 

--- a/src/Core__Error.res
+++ b/src/Core__Error.res
@@ -37,3 +37,5 @@ module URIError = {
 external raise: t => 'a = "%raise"
 
 let panic = msg => make(`Panic! ${msg}`)->raise
+
+external raiseAny: 'a => unit = "%raise"

--- a/src/Core__Error.resi
+++ b/src/Core__Error.resi
@@ -169,3 +169,17 @@ Error.panic("Uh oh. This was unexpected!")
 ```
 */
 let panic: string => 'a
+
+/** `raiseAny` throws (or re-throws) an exception of any kind. See [throw on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw) and [exceptions in ReScript](https://rescript-lang.org/docs/manual/latest/exception)
+
+## Examples
+```rescript
+try {
+  Error.make("A problem occurred.")->Error.raise
+} catch {
+| _ as exn =>
+  Console.log("Caught it but can't handle it.")
+  Error.raiseAny(exn) // throw it again
+```
+*/
+external raiseAny: 'a => unit = "%raise"

--- a/src/Core__Error.resi
+++ b/src/Core__Error.resi
@@ -175,10 +175,10 @@ let panic: string => 'a
 ## Examples
 ```rescript
 try {
-  Error.make("A problem occurred.")->Error.raise
+  somethingDangerous()   
 } catch {
 | _ as exn =>
-  Console.log("Caught it but can't handle it.")
+  Console.log("Caught it...but can't handle it.")
   Error.raiseAny(exn) // throw it again
 ```
 */

--- a/test/ErrorTests.mjs
+++ b/test/ErrorTests.mjs
@@ -33,7 +33,32 @@ function panicTest(param) {
 
 panicTest(undefined);
 
+var received = false;
+
+var err = new Error("something went wrong");
+
+try {
+  throw err;
+}
+catch (exn){
+  console.log("An exception happened!");
+  throw exn;
+}
+
+var raiseAnyCanThrowAgain = Test.run([
+      [
+        "ErrorTests.res",
+        34,
+        22,
+        39
+      ],
+      "Can throw again"
+    ], received, (function (prim0, prim1) {
+        return prim0 === prim1;
+      }), true);
+
 export {
   panicTest ,
+  raiseAnyCanThrowAgain ,
 }
 /*  Not a pure module */

--- a/test/ErrorTests.mjs
+++ b/test/ErrorTests.mjs
@@ -2,6 +2,7 @@
 
 import * as Test from "./Test.mjs";
 import * as Js_exn from "rescript/lib/es6/js_exn.js";
+import * as Caml_option from "rescript/lib/es6/caml_option.js";
 import * as RescriptCore from "../src/RescriptCore.mjs";
 import * as Caml_js_exceptions from "rescript/lib/es6/caml_js_exceptions.js";
 
@@ -33,29 +34,40 @@ function panicTest(param) {
 
 panicTest(undefined);
 
-var received = false;
-
-var err = new Error("something went wrong");
-
-try {
-  throw err;
+function raiseAnyCanThrowAgain(param) {
+  var received = false;
+  var err = new Error("something went wrong");
+  try {
+    throw err;
+  }
+  catch (exn){
+    console.log("An exception happened!");
+    try {
+      throw exn;
+    }
+    catch (raw_exn){
+      var exn$1 = Caml_js_exceptions.internalToOCamlException(raw_exn);
+      var e = Caml_js_exceptions.as_js_exn(exn$1);
+      if (e !== undefined) {
+        received = Caml_option.valFromOption(e) === err;
+      }
+      
+    }
+  }
+  Test.run([
+        [
+          "ErrorTests.res",
+          33,
+          22,
+          39
+        ],
+        "Can throw again"
+      ], received, (function (prim0, prim1) {
+          return prim0 === prim1;
+        }), true);
 }
-catch (exn){
-  console.log("An exception happened!");
-  throw exn;
-}
 
-var raiseAnyCanThrowAgain = Test.run([
-      [
-        "ErrorTests.res",
-        34,
-        22,
-        39
-      ],
-      "Can throw again"
-    ], received, (function (prim0, prim1) {
-        return prim0 === prim1;
-      }), true);
+raiseAnyCanThrowAgain(undefined);
 
 export {
   panicTest ,

--- a/test/ErrorTests.res
+++ b/test/ErrorTests.res
@@ -9,3 +9,27 @@ let panicTest = () => {
 }
 
 panicTest()
+
+// ===== RaiseAny =====
+
+let raiseAnyCanThrowAgain = {
+  let received = ref(false)
+  let err = Error.make("something went wrong")
+  try {
+    Error.raise(err)
+  } catch {
+  | _ as exn =>
+    Console.log("An exception happened!")
+    Error.raiseAny(exn) // throw it again
+    try {
+      Error.raiseAny(exn) // rethrow it
+    } catch {
+    | _ as exn =>
+      switch exn->Error.fromException {
+      | None => ()
+      | Some(e) => received := e === err
+      }
+    }
+  }
+  Test.run(__POS_OF__("Can throw again"), received.contents, \"==", true)
+}

--- a/test/ErrorTests.res
+++ b/test/ErrorTests.res
@@ -10,7 +10,7 @@ let panicTest = () => {
 
 panicTest()
 
-// ===== RaiseAny =====
+// ===== raiseAny =====
 
 let raiseAnyCanThrowAgain = {
   let received = ref(false)

--- a/test/ErrorTests.res
+++ b/test/ErrorTests.res
@@ -12,7 +12,7 @@ panicTest()
 
 // ===== raiseAny =====
 
-let raiseAnyCanThrowAgain = {
+let raiseAnyCanThrowAgain = () => {
   let received = ref(false)
   let err = Error.make("something went wrong")
   try {
@@ -20,7 +20,6 @@ let raiseAnyCanThrowAgain = {
   } catch {
   | _ as exn =>
     Console.log("An exception happened!")
-    Error.raiseAny(exn) // throw it again
     try {
       Error.raiseAny(exn) // rethrow it
     } catch {
@@ -33,3 +32,5 @@ let raiseAnyCanThrowAgain = {
   }
   Test.run(__POS_OF__("Can throw again"), received.contents, \"==", true)
 }
+
+raiseAnyCanThrowAgain()

--- a/test/TestSuite.mjs
+++ b/test/TestSuite.mjs
@@ -27,6 +27,8 @@ var Concurrently = PromiseTest.Concurrently;
 
 var panicTest = ErrorTests.panicTest;
 
+var raiseAnyCanThrowAgain = ErrorTests.raiseAnyCanThrowAgain;
+
 var $$catch = IntTests.$$catch;
 
 var eq = ResultTests.eq;
@@ -46,6 +48,7 @@ export {
   Catching ,
   Concurrently ,
   panicTest ,
+  raiseAnyCanThrowAgain ,
   $$catch ,
   eq ,
   forEachIfOkCallFunction ,


### PR DESCRIPTION
This is my attempt at fixing the problem I raised in https://github.com/rescript-association/rescript-core/issues/101, which is basically that I am inspecting an exception and then want to re-throw the `exn` (not an `Error.t`). I could not find a way to do that with the `Error` module, which is where I would expect to find it. My proposed fix is makes the throw statement return a `unit`, although every other raise command returns a `'a`. What is correct?