### PR TITLE
Error.getUnsafe

### DIFF
--- a/src/Core__Error.res
+++ b/src/Core__Error.res
@@ -37,3 +37,5 @@ module URIError = {
 external raise: t => 'a = "%raise"
 
 let panic = msg => make(`Panic! ${msg}`)->raise
+
+@get_index external getUnsafe: ('a, string) => option<'b> = ""

--- a/src/Core__Error.resi
+++ b/src/Core__Error.resi
@@ -169,3 +169,27 @@ Error.panic("Uh oh. This was unexpected!")
 ```
 */
 let panic: string => 'a
+
+/**
+`getUnsafe` returns a custom property on an error object, given its name. This is useful for working with custom exceptions thrown from JavaScript.
+
+**Warning:** The return type is not guaranteed to be what you expect. It can be a string or null or anthing else. Run-time errors can occur if you use it as something that it is not. Consider the functions in the `Type` module to safely access its contents. ReScript exceptions can be handled in a type-safe way. See [Exceptions in ReScript](https://rescript-lang.org/docs/manual/latest/exception).
+
+## Examples
+```rescript
+switch exn->Error.fromException {
+| None => raise(exn) 
+| Some(err) =>
+  switch err->Error.getUnsafe("code") {
+  | None => raise(exn)
+  | Some(code) => {
+      if (code === "invalid-password") {
+        Console.log("Try again!")  
+      }
+    }
+  }
+}
+```
+*/
+@get_index
+external getUnsafe: (t, string) => option<'a> = ""

--- a/test/ErrorTests.res
+++ b/test/ErrorTests.res
@@ -9,3 +9,33 @@ let panicTest = () => {
 }
 
 panicTest()
+
+// This test case is based on catching authentication errors from the Firebase
+// SDK. Errors are subclassed from the Error object and contain custom
+// properties like "code".
+let catchCustomError = () => {
+  let authenticationError = Error.make("authentication error")
+  let codeCaught = ref(None)
+  Object.set(authenticationError->Obj.magic, "code", "invalid-password")
+  try {
+    authenticationError->Error.raise
+  } catch {
+  | _ as exn =>
+    switch exn->Error.fromException {
+    | None => raise(exn)
+    | Some(err) =>
+      switch err->Error.getUnsafe("code") {
+      | None => ()
+      | Some(code) => codeCaught := Some(code)
+      }
+    }
+  }
+  Test.run(
+    __POS_OF__("Can access custom code"),
+    codeCaught.contents,
+    \"==",
+    Some("invalid-password"),
+  )
+}
+
+catchCustomError()

--- a/test/TestSuite.mjs
+++ b/test/TestSuite.mjs
@@ -27,6 +27,8 @@ var Concurrently = PromiseTest.Concurrently;
 
 var panicTest = ErrorTests.panicTest;
 
+var catchCustomError = ErrorTests.catchCustomError;
+
 var $$catch = IntTests.$$catch;
 
 var eq = ResultTests.eq;
@@ -46,6 +48,7 @@ export {
   Catching ,
   Concurrently ,
   panicTest ,
+  catchCustomError ,
   $$catch ,
   eq ,
   forEachIfOkCallFunction ,


### PR DESCRIPTION
Provides a way to get a custom property value out of an Error. Includes full documentation, warnings, and a test. This satisfies a real-world scenario of me trying to get the "code" property out of a Firebase SDK exception. See discussion in 
https://github.com/rescript-association/rescript-core/issues/102.