### PR TITLE
specify peer's compiler version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "src/**/*.resi"
   ],
   "peerDependencies": {
-    "rescript": "^10.0.0 || next"
+    "rescript": ">= 10.1.0"
   },
   "devDependencies": {
     "rescript": "10.1.4",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "src/**/*.res",
     "src/**/*.resi"
   ],
+  "peerDependencies": {
+    "rescript": "^10.0.0 || next"
+  },
   "devDependencies": {
     "rescript": "10.1.4",
     "@babel/code-frame": "7.18.6"


### PR DESCRIPTION
As long as this package requires a specific compiler version, it's good practice to specify the `peerDepenencies` list explicitly. So allows the package managers to warn or block the use of mismatched versions in advance.

If the required compiler version goes up, such as [`Promise.allSettled` binding](https://github.com/rescript-lang/rescript-compiler/pull/6137), the `^v10.0.0` scope should be removed before bump.