### PR TITLE
make String.localeCompare return an int

### DIFF
--- a/src/Core__String.res
+++ b/src/Core__String.res
@@ -130,4 +130,4 @@ external splitByRegExpAtMost: (string, Core__RegExp.t, ~limit: int) => array<opt
 @get_index external getSymbolUnsafe: (string, Core__Symbol.t) => 'a = ""
 @set_index external setSymbol: (string, Core__Symbol.t, 'a) => unit = ""
 
-@send external localeCompare: (string, string) => float = "localeCompare"
+@send external localeCompare: (string, string) => int = "localeCompare"

--- a/src/Core__String.resi
+++ b/src/Core__String.resi
@@ -970,9 +970,9 @@ See [`String.localeCompare`](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 ## Examples
 
 ```rescript
-String.localeCompare("a", "c") < 0.0 == true
-String.localeCompare("a", "a") == 0.0
+String.localeCompare("a", "c") < 0 == true
+String.localeCompare("a", "a") == 0
 ```
 */
 @send
-external localeCompare: (string, string) => float = "localeCompare"
+external localeCompare: (string, string) => int = "localeCompare"


### PR DESCRIPTION
[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare#description) states that localeCompare "returns an integer indicating whether the referenceStr comes before, after or is equivalent to the compareString."
