### PR TITLE
fix peerDeps range

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "src/**/*.resi"
   ],
   "peerDependencies": {
-    "rescript": ">= 10.1.0"
+    "rescript": "^10.1.0 || ^11.0.0-alpha.0 || next"
   },
   "devDependencies": {
     "rescript": "10.1.4",


### PR DESCRIPTION
Tested with packed module via `npm pack`

this code explains about regular semver range
```js
const assert = require('node:assert');
const semver = require('semver');

const range = '^10.1.0 || ^11.0.0-alpha.0';

assert(
  !semver.satisfies('10.0.0', range),
);

assert(
  semver.satisfies('10.1.4', range),
);

assert(
  semver.satisfies('11.0.0-alpha.5', range),
);

assert(
  semver.satisfies('11.0.0', range),
);
```

And added `next` non-semver range
