### PR TITLE
Explicitly list out our source dirs

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -4,11 +4,10 @@
   "sources": [
     {
       "dir": "src",
-      "subdirs": true
+      "subdirs": ["intl", "typed-arrays"]
     },
     {
       "dir": "test",
-      "subdirs": true,
       "type": "dev"
     }
   ],


### PR DESCRIPTION
Afaik it was still faster due to not needing some kind of directory scan. Might be no longer true, but yeah nothing wrong with this just in case.
