### PR TITLE
Upgrade Test stack trace cleaning function

### DIFF
--- a/test/Test.mjs
+++ b/test/Test.mjs
@@ -9,25 +9,6 @@ import * as CodeFrame from "@babel/code-frame";
 
 var dirname = (new URL('.', import.meta.url).pathname);
 
-function cleanUpStackTrace(stack) {
-  var removeInternalLines = function (lines, _i) {
-    while(true) {
-      var i = _i;
-      if (i >= lines.length) {
-        return lines;
-      }
-      if (lines[i].indexOf(" (internal/") >= 0) {
-        return lines.slice(0, i);
-      }
-      _i = i + 1 | 0;
-      continue ;
-    };
-  };
-  return removeInternalLines(stack.split("\n").slice(2), 0).map(function (line) {
-                return line.slice(2);
-              }).join("\n");
-}
-
 function print(value) {
   var match = typeof value;
   if (match === "object" || match === "bigint") {
@@ -62,12 +43,11 @@ function run(loc, left, comparator, right) {
   console.log(errorMessage);
   var obj = {};
   Error.captureStackTrace(obj);
-  console.log(cleanUpStackTrace(obj.stack));
+  console.log(obj.stack.replace(/\n    /g, "\n  ").replace(/^Error\n/, "").replace(/^.+\n/, "").replace(/\n  at .+\(node:internal.+\n?/g, ""));
 }
 
 export {
   dirname ,
-  cleanUpStackTrace ,
   print ,
   run ,
 }


### PR DESCRIPTION
The stack format change slightly and we were no longer matching on the correct stuff to clean up: "(internal/..." became "(node:internal/..."

Took the occasion to swap them out with regex and inline the one-off cleanup logic too (IIRC I kept it separate because not all repos wanted that cleanup. But nobody cares now)

Before:
<img width="872" alt="Screenshot 2023-05-22 at 03 43 30" src="https://github.com/rescript-association/rescript-core/assets/1909539/2732e0dd-15b1-42a6-b73f-802d6de36650">
After:
<img width="844" alt="Screenshot 2023-05-22 at 03 43 08" src="https://github.com/rescript-association/rescript-core/assets/1909539/a69d8ef4-4800-487b-9635-a8a21e8fe149">

