### PR TITLE
Map, Set, WeakMap, WeakSet: use types from Js namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### API changes
 
+- Map, Set, WeakMap, WeakSet: use the types defined in the Js namespace. https://github.com/rescript-association/rescript-core/pull/143
 - `Array` mutable & immutable helper name changed to conform to JS' upcoming APIs [such as `toSorted`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted)
   - `sort` -> `toSorted`, `sortInPlace` -> `sort`
   - `reverse` -> `toReversed`, `reverseInPlace` -> `reverse`

--- a/src/Core__Map.res
+++ b/src/Core__Map.res
@@ -1,4 +1,4 @@
-type t<'k, 'v>
+type t<'k, 'v> = Js.Map.t<'k, 'v>
 
 @new external make: unit => t<'k, 'v> = "Map"
 @new external fromArray: array<('k, 'v)> => t<'k, 'v> = "Map"

--- a/src/Core__Map.resi
+++ b/src/Core__Map.resi
@@ -7,7 +7,7 @@ See [`Map`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Gl
 /**
 Type representing an instance of `Map`.
 */
-type t<'k, 'v>
+type t<'k, 'v> = Js.Map.t<'k, 'v>
 
 /**
 Creates a new, mutable JavaScript `Map`. A `Map` can have any values as both keys and values.

--- a/src/Core__Set.res
+++ b/src/Core__Set.res
@@ -1,4 +1,4 @@
-type t<'a>
+type t<'a> = Js.Set.t<'a>
 
 @new external make: unit => t<'a> = "Set"
 @new external fromArray: array<'a> => t<'a> = "Set"

--- a/src/Core__Set.resi
+++ b/src/Core__Set.resi
@@ -7,7 +7,7 @@ See [`Set`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Gl
 /**
 Type representing an instance of `Set`.
 */
-type t<'a>
+type t<'a> = Js.Set.t<'a>
 
 /**
 Creates a new, mutable JavaScript `Set`. A `Set` is a collection of unique values.

--- a/src/Core__WeakMap.res
+++ b/src/Core__WeakMap.res
@@ -1,4 +1,4 @@
-type t<'k, 'v>
+type t<'k, 'v> = Js.WeakMap.t<'k, 'v>
 
 @new external make: unit => t<'k, 'v> = "WeakMap"
 

--- a/src/Core__WeakSet.res
+++ b/src/Core__WeakSet.res
@@ -1,4 +1,4 @@
-type t<'a>
+type t<'a> = Js.WeakSet.t<'a>
 
 @new external make: unit => t<'a> = "WeakSet"
 


### PR DESCRIPTION
Placeholder types for ES6 collections were added to the Js namespace in https://github.com/rescript-lang/rescript-compiler/pull/5630.

We should use these in Core.