### PR TITLE
chore(ci): update node matrix

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x, 20.x]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Removes 16.x, which is now unsupported.
Replaces 19.x with 20.x as the current release

This should unblock #126