### PR TITLE
Only allow to join actual strings with Array.joinWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### API changes
 
 - Add `Math.Int.floor` and `Math.Int.random`, https://github.com/rescript-association/rescript-core/pull/156
+- Change `Array.joinWith`s signature to accept only string arrays and add `Array.joinWithUnsafe` with the polymorphic signature of the former https://github.com/rescript-association/rescript-core/pull/157
 
 ### Documentation
 

--- a/src/Core__Array.res
+++ b/src/Core__Array.res
@@ -125,6 +125,8 @@ let indexOfOpt = (arr, item) =>
 
 @send external joinWith: (array<string>, string) => string = "join"
 
+@send external joinWithUnsafe: (array<'a>, string) => string = "join"
+
 @send external lastIndexOf: (array<'a>, 'a) => int = "lastIndexOf"
 let lastIndexOfOpt = (arr, item) =>
   switch arr->lastIndexOf(item) {

--- a/src/Core__Array.res
+++ b/src/Core__Array.res
@@ -123,7 +123,7 @@ let indexOfOpt = (arr, item) =>
   }
 @send external indexOfFrom: (array<'a>, 'a, int) => int = "indexOf"
 
-@send external joinWith: (array<'a>, string) => string = "join"
+@send external joinWith: (array<string>, string) => string = "join"
 
 @send external lastIndexOf: (array<'a>, 'a) => int = "lastIndexOf"
 let lastIndexOfOpt = (arr, item) =>

--- a/src/Core__Array.resi
+++ b/src/Core__Array.resi
@@ -384,17 +384,30 @@ let indexOfOpt: (array<'a>, 'a) => option<int>
 @send external indexOfFrom: (array<'a>, 'a, int) => int = "indexOf"
 
 /**
-`joinWith(array, separator)` produces a string where all items of `array` are printed, separated by `separator`. Under the hood this will run JavaScript's `toString` on all the array items.
+`joinWith(array, separator)` produces a string where all items of `array` are printed, separated by `separator`. Array items must be strings, to join number or other arrays, use `joinWithUnsafe`. Under the hood this will run JavaScript's `toString` on all the array items.
+
+## Examples
+```rescript
+let array = ["One", "Two", "Three"]
+
+Console.log(array->Array.joinWith(" -- ")) // One -- Two -- Three
+```
+*/
+@send
+external joinWith: (array<string>, string) => string = "join"
+
+/**
+`joinWithUnsafe(array, separator)` produces a string where all items of `array` are printed, separated by `separator`. Under the hood this will run JavaScript's `toString` on all the array items.
 
 ## Examples
 ```rescript
 let array = [1, 2, 3]
 
-Console.log(array->Array.joinWith(" -- ")) // 1 -- 2 -- 3
+Console.log(array->Array.joinWithUnsafe(" -- ")) // 1 -- 2 -- 3
 ```
 */
 @send
-external joinWith: (array<'a>, string) => string = "join"
+external joinWithUnsafe: (array<'a>, string) => string = "join"
 @send external lastIndexOf: (array<'a>, 'a) => int = "lastIndexOf"
 let lastIndexOfOpt: (array<'a>, 'a) => option<int>
 @send external lastIndexOfFrom: (array<'a>, 'a, int) => int = "lastIndexOf"


### PR DESCRIPTION
The old `joinWith` binding sometimes led me to write code that resulted in `[object Object]` which cannot happen with this stricter signature. Not sure if the unsafe variant is really needed.