### PR TITLE
Rename Object.empty to Object.make

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `Dict.forEach`, `Dict.forEachWithKey` and `Dict.mapValues` https://github.com/rescript-association/rescript-core/pull/181
 - Remove internal xxxU helper functions that are not needed anymore in uncurried mode. https://github.com/rescript-association/rescript-core/pull/191
+- Rename `Object.empty` to `Object.make` for consistency.
 
 ## 1.0.0
 

--- a/src/Core__Object.res
+++ b/src/Core__Object.res
@@ -1,16 +1,16 @@
 /**
-`empty` create a new object that inherits the properties and methods from the standard built-in Object, such as `toString`. See [Object on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
+`make` create a new object that inherits the properties and methods from the standard built-in Object, such as `toString`. See [Object on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 
 ## Examples
 
 ```rescript
-let x = Object.empty()
+let x = Object.make()
 x->Object.keysToArray->Array.length // 0
 x->Object.get("toString")->Option.isSome // true
 ```
 */
 @obj
-external empty: unit => {..} = ""
+external make: unit => {..} = ""
 
 /**
 `is` determines if two objects are identical in all contexts. Objects, arrays, records, and other non-primitives are only identical if they reference the **exact** same object in memory. Primitives like ints, floats, and strings are identical if they have the same value. `+0` and `-0` are distinct. NaN is equal to itself. See [Object.is on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is)
@@ -117,7 +117,7 @@ external get: ({..}, string) => option<'a> = ""
 
 ```rescript
 let fruit = Symbol.make("fruit")
-let x = Object.empty()
+let x = Object.make()
 x->Object.setSymbol(fruit, "banana")
 x->Object.getSymbol(fruit) // Some("banana")
 ```
@@ -152,7 +152,7 @@ or [Object.keys on MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/
 ```rescript
 {"a": 1, "b": 2}->Object.keysToArray // ["a", "b"]
 {"a": None}->Object.keysToArray // ["a"]
-Object.empty()->Object.keysToArray // []
+Object.make()->Object.keysToArray // []
 ```
 */
 @val

--- a/test/ObjectTests.res
+++ b/test/ObjectTests.res
@@ -40,7 +40,7 @@ Test.run(__POS_OF__("is: date"), Object.is(d, d), eq, true)
 let x = {"a": 1}
 Test.run(__POS_OF__("is: objects"), Object.is(x, x), eq, true)
 Test.run(__POS_OF__("is: objects"), Object.is({"a": 1}, {"a": 1}), eq, false)
-Test.run(__POS_OF__("is: objects"), Object.is(Object.empty(), Object.empty()), eq, false) // hmm...
+Test.run(__POS_OF__("is: objects"), Object.is(Object.make(), Object.make()), eq, false) // hmm...
 Test.run(__POS_OF__("is: === and == operator"), x === x, eq, true)
 Test.run(__POS_OF__("is: === and == operator"), x == x, eq, true)
 Test.run(__POS_OF__("is: === and == operator"), {"a": 1} == {"a": 1}, eq, true)
@@ -142,7 +142,7 @@ let runGetTest = i =>
 // ===== getSymbol =====
 
 let getSymbolTestWhenExists = () => {
-  let obj = Object.empty()
+  let obj = Object.make()
   let fruit = Symbol.make("fruit")
   obj->Object.setSymbol(fruit, "banana")
   let retrieved = obj->Object.getSymbol(fruit)
@@ -157,7 +157,7 @@ getSymbolTestWhenExists()
 
 Test.run(
   __POS_OF__(`Object.getSymbol when not exists return it as None`),
-  Object.empty()->Object.getSymbol(Symbol.make("fruit")),
+  Object.make()->Object.getSymbol(Symbol.make("fruit")),
   eq,
   None,
 )

--- a/test/Test.res
+++ b/test/Test.res
@@ -39,7 +39,7 @@ ${codeFrame}
 `
     Console.log(errorMessage)
     // API: https://nodejs.org/api/errors.html#errors_error_capturestacktrace_targetobject_constructoropt
-    let obj = Object.empty()
+    let obj = Object.make()
     captureStackTrace(obj)
     // clean up stack trace! Stack format: https://nodejs.org/api/errors.html#errors_error_stack
     obj["stack"]


### PR DESCRIPTION
`Dict` and every other module uses `make` to create empty collections. For consistency, `Object` should do the same.