### PR TITLE
Add Array.flatMapWithIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 
 - Fix: Expose Intl.Common. https://github.com/rescript-association/rescript-core/pull/197
+- Add `Array.flatMapWithIndex` https://github.com/rescript-association/rescript-core/pull/199
 
 ## 1.1.0
 

--- a/src/Core__Array.res
+++ b/src/Core__Array.res
@@ -230,6 +230,7 @@ let filterMap = (a, f) => {
 let keepSome = filterMap(_, x => x)
 
 @send external flatMap: (array<'a>, 'a => array<'b>) => array<'b> = "flatMap"
+@send external flatMapWithIndex: (array<'a>, ('a, int) => array<'b>) => array<'b> = "flatMap"
 
 let findMap = (arr, f) => {
   let rec loop = i =>

--- a/src/Core__Array.resi
+++ b/src/Core__Array.resi
@@ -969,6 +969,30 @@ Console.log(
 external flatMap: (array<'a>, 'a => array<'b>) => array<'b> = "flatMap"
 
 /**
+`flatMapWithIndex(array, mapper)` returns a new array concatenating the arrays returned from running `mapper` on all items in `array`.
+
+## Examples
+```rescript
+type language = ReScript | TypeScript | JavaScript
+
+let array = [ReScript, TypeScript, JavaScript]
+
+Console.log(
+  array->Array.flatMapWithIndex((item, index) =>
+    switch item {
+    | ReScript => [index]
+    | TypeScript => [index, index + 1]
+    | JavaScript => [index, index + 1, index + 2]
+    }
+  ),
+)
+// [0, 1, 2, 2, 3, 4]
+```
+*/
+@send
+external flatMapWithIndex: (array<'a>, ('a, int) => array<'b>) => array<'b> = "flatMap"
+
+/**
   `findMap(arr, fn)`
 
   Calls `fn` for each element and returns the first value from `fn` that is `Some(_)`.


### PR DESCRIPTION
[`Array.prototype.flatMap` passes the current element's index to its callback argument](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap#callbackfn) but we do not have a `Array.flatMapWithIndex` function.