### PR TITLE
Int, Float, BigInt: use optional args and deprecate xxxWithRadix, xxxWithPrecision etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 
 - BREAKING: Use new native `bigint` type. This requires ReScript compiler version "11.1.0-rc.6" or higher. https://github.com/rescript-association/rescript-core/pull/207
+- `Int`, `Float`, `BigInt`: use optional args and deprecate `xxxWithRadix`, `xxxWithPrecision` etc. https://github.com/rescript-association/rescript-core/pull/209
 
 ## 1.2.0
 

--- a/scripts/DocTests.mjs
+++ b/scripts/DocTests.mjs
@@ -306,7 +306,7 @@ async function main() {
             var id = example.id.replaceAll(".", "_");
             var codes = getCodeBlocks(example);
             var results = await Promise.all(codes.map(async function (code, $$int) {
-                      var id$1 = id + "_" + $$int.toString();
+                      var id$1 = id + "_" + $$int.toString(undefined);
                       return await testCode(id$1, code);
                     }));
             return [

--- a/src/Core__BigInt.res
+++ b/src/Core__BigInt.res
@@ -50,8 +50,10 @@ See [`toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Referen
 Js.BigInt.toString(123n)->Js.log
 ```
 */
-external toString: bigint => string = "toString"
-@send external toStringWithRadix: (bigint, ~radix: int) => string = "toString"
+external toString: (bigint, ~radix: int=?) => string = "toString"
+
+@deprecated("Use `toString` with `~radix` instead") @send
+external toStringWithRadix: (bigint, ~radix: int) => string = "toString"
 
 @send
 /**

--- a/src/Core__Dict.resi
+++ b/src/Core__Dict.resi
@@ -228,7 +228,7 @@ let forEachWithKey: (t<'a>, ('a, string) => unit) => unit
 let dict = Dict.fromArray([("key1", 1), ("key2", 2)])
 
 dict->Dict.mapValues(v => v + 10)->Dict.toArray // [("key1", 11), ("key2", 12)]
-dict->Dict.mapValues(Int.toString)->Dict.toArray // [("key1", "1"), ("key2", "2")]
+dict->Dict.mapValues(v => Int.toString(v))->Dict.toArray // [("key1", "1"), ("key2", "2")]
 ```
 */
 let mapValues: (t<'a>, 'a => 'b) => t<'b>

--- a/src/Core__Float.res
+++ b/src/Core__Float.res
@@ -16,20 +16,25 @@ let compare = (a: float, b: float) =>
 @val external isFinite: float => bool = "isFinite"
 @val external parseFloat: 'a => float = "parseFloat"
 // parseInt's return type is a float because it can be NaN
-@val external parseInt: 'a => float = "parseInt"
-@val external parseIntWithRadix: ('a, ~radix: int) => float = "parseInt"
+@val external parseInt: ('a, ~radix: int=?) => float = "parseInt"
+@deprecated("Use `parseInt` instead") @val
+external parseIntWithRadix: ('a, ~radix: int) => float = "parseInt"
 
-@send external toExponential: float => string = "toExponential"
-@send external toExponentialWithPrecision: (float, ~digits: int) => string = "toExponential"
+@send external toExponential: (float, ~digits: int=?) => string = "toExponential"
+@deprecated("Use `toExponential` instead") @send
+external toExponentialWithPrecision: (float, ~digits: int) => string = "toExponential"
 
-@send external toFixed: float => string = "toFixed"
-@send external toFixedWithPrecision: (float, ~digits: int) => string = "toFixed"
+@send external toFixed: (float, ~digits: int=?) => string = "toFixed"
+@deprecated("Use `toFixed` instead") @send
+external toFixedWithPrecision: (float, ~digits: int) => string = "toFixed"
 
-@send external toPrecision: float => string = "toPrecision"
-@send external toPrecisionWithPrecision: (float, ~digits: int) => string = "toPrecision"
+@send external toPrecision: (float, ~digits: int=?) => string = "toPrecision"
+@deprecated("Use `toPrecision` instead") @send
+external toPrecisionWithPrecision: (float, ~digits: int) => string = "toPrecision"
 
-@send external toString: float => string = "toString"
-@send external toStringWithRadix: (float, ~radix: int) => string = "toString"
+@send external toString: (float, ~radix: int=?) => string = "toString"
+@deprecated("Use `toString` instead") @send
+external toStringWithRadix: (float, ~radix: int) => string = "toString"
 @send external toLocaleString: float => string = "toLocaleString"
 
 let fromString = i =>

--- a/src/Core__Float.resi
+++ b/src/Core__Float.resi
@@ -162,8 +162,11 @@ Float.parseFloat("error")->Float.isNaN // true
 external parseFloat: string => float = "parseFloat"
 
 /**
-`parseInt(v)` parse the given `v` and returns a float. Leading whitespace in
-`v` is ignored. Returns `NaN` if `v` can't be parsed.
+`parseInt(v, ~radix=?)` parse the given `v` and returns a float. Leading
+whitespace in this argument `v`is ignored. `radix` specifies the radix base to
+use for the formatted number. The value must be in the range [2, 36] (inclusive).
+Returns `NaN` if `v` can't be parsed and `radix` is smaller than 2 or bigger
+than 36.
 See [`parseInt`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt) on MDN.
 
 ## Examples
@@ -174,10 +177,14 @@ Float.parseInt("  3.14   ") // 3.0
 Float.parseInt(3) // 3.0
 Float.parseInt("3.14some non-digit characters") // 3.0
 Float.parseInt("error")->Float.isNaN // true
+Float.parseInt("10.0", ~radix=2) // 2.0
+Float.parseInt("15 * 3", ~radix=10) // 15.0
+Float.parseInt("12", ~radix=13) // 15.0
+Float.parseInt("17", ~radix=40)->Float.isNaN // true
 ```
 */
 @val
-external parseInt: 'a => float = "parseInt"
+external parseInt: ('a, ~radix: int=?) => float = "parseInt"
 
 /**
 `parseIntWithRadix(v, ~radix)` parse the given `v` and returns a float. Leading
@@ -196,12 +203,14 @@ Float.parseIntWithRadix("12", ~radix=13) // 15.0
 Float.parseIntWithRadix("17", ~radix=40)->Float.isNaN // true
 ```
 */
+@deprecated("Use `parseInt` instead")
 @val
 external parseIntWithRadix: ('a, ~radix: int) => float = "parseInt"
 
 /**
-`toExponential(v)` return a `string` representing the given value in exponential
-notation.
+`toExponential(v, ~digits=?)` return a `string` representing the given value in
+exponential notation. `digits` specifies how many digits should appear after
+the decimal point.
 See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential) on MDN.
 
 ## Examples
@@ -209,10 +218,17 @@ See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaSc
 ```rescript
 Float.toExponential(1000.0) // "1e+3"
 Float.toExponential(-1000.0) // "-1e+3"
+Float.toExponential(77.0, ~digits=2) // "7.70e+1"
+Float.toExponential(5678.0, ~digits=2) // "5.68e+3"
+```
+
+## Exceptions
+
+- `RangeError`: If `digits` less than 0 or greater than 10.
 ```
 */
 @send
-external toExponential: float => string = "toExponential"
+external toExponential: (float, ~digits: int=?) => string = "toExponential"
 
 /**
 `toExponential(v, ~digits)` return a `string` representing the given value in
@@ -231,12 +247,14 @@ Float.toExponentialWithPrecision(5678.0, ~digits=2) // "5.68e+3"
 
 - `RangeError`: If `digits` less than 0 or greater than 10.
 */
+@deprecated("Use `toExponential` instead")
 @send
 external toExponentialWithPrecision: (float, ~digits: int) => string = "toExponential"
 
 /**
-`toFixed(v)` return a `string` representing the given value using fixed-point
-notation.
+`toFixed(v, ~digits=?)` return a `string` representing the given
+value using fixed-point notation. `digits` specifies how many digits should
+appear after the decimal point.
 See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed) on MDN.
 
 ## Examples
@@ -244,10 +262,16 @@ See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/R
 ```rescript
 Float.toFixed(123456.0) // "123456.00"
 Float.toFixed(10.0) // "10.00"
+Float.toFixed(300.0, ~digits=4) // "300.0000"
+Float.toFixed(300.0, ~digits=1) // "300.0"
 ```
+
+## Exceptions
+
+- `RangeError`: If `digits` is less than 0 or larger than 100.
 */
 @send
-external toFixed: float => string = "toFixed"
+external toFixed: (float, ~digits: int=?) => string = "toFixed"
 
 /**
 `toFixedWithPrecision(v, ~digits)` return a `string` representing the given
@@ -266,13 +290,13 @@ Float.toFixedWithPrecision(300.0, ~digits=1) // "300.0"
 
 - `RangeError`: If `digits` is less than 0 or larger than 100.
 */
+@deprecated("Use `toFixed` instead")
 @send
 external toFixedWithPrecision: (float, ~digits: int) => string = "toFixed"
 
 /**
-`toPrecision(v)` return a `string` representing the giver value with precision.
-This function omits the argument that controls precision, so it behaves like
-`toString`. See `toPrecisionWithPrecision` to control precision.
+`toPrecision(v, ~digits=?)` return a `string` representing the giver value with
+precision. `digits` specifies the number of significant digits.
 See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.
 
 ## Examples
@@ -280,10 +304,18 @@ See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScri
 ```rescript
 Float.toPrecision(100.0) // "100"
 Float.toPrecision(1.0) // "1"
+Float.toPrecision(100.0, ~digits=2) // "1.0e+2"
+Float.toPrecision(1.0, ~digits=1) // "1"
 ```
+
+## Exceptions
+
+- `RangeError`: If `digits` is not between 1 and 100 (inclusive).
+Implementations are allowed to support larger and smaller values as well.
+ECMA-262 only requires a precision of up to 21 significant digits.
 */
 @send
-external toPrecision: float => string = "toPrecision"
+external toPrecision: (float, ~digits: int=?) => string = "toPrecision"
 
 /**
 `toPrecisionWithPrecision(v, ~digits)` return a `string` representing the giver value with
@@ -304,6 +336,7 @@ Implementations are allowed to support larger and smaller values as well.
 ECMA-262 only requires a precision of up to 21 significant digits.
 
 */
+@deprecated("Use `toPrecision` instead")
 @send
 external toPrecisionWithPrecision: (float, ~digits: int) => string = "toPrecision"
 
@@ -319,7 +352,7 @@ Float.toString(-1000.0) // "-1000"
 ```
 */
 @send
-external toString: float => string = "toString"
+external toString: (float, ~radix: int=?) => string = "toString"
 
 /**
 `toStringWithRadix(v, ~radix)` return a `string` representing the given value.
@@ -338,6 +371,7 @@ Float.toStringWithRadix(123456.0, ~radix=36) // "2n9c"
 
 `RangeError`: if `radix` is less than 2 or greater than 36.
 */
+@deprecated("Use `toString` with `~radix` instead")
 @send
 external toStringWithRadix: (float, ~radix: int) => string = "toString"
 

--- a/src/Core__Int.mjs
+++ b/src/Core__Int.mjs
@@ -17,7 +17,7 @@ function compare(a, b) {
   }
 }
 
-function fromString(radix, x) {
+function fromString(x, radix) {
   var maybeInt = radix !== undefined ? parseInt(x, radix) : parseInt(x);
   if (isNaN(maybeInt) || maybeInt > 2147483647 || maybeInt < -2147483648) {
     return ;
@@ -26,7 +26,8 @@ function fromString(radix, x) {
   }
 }
 
-function rangeWithOptions(start, end, options) {
+function range(start, end, optionsOpt) {
+  var options = optionsOpt !== undefined ? optionsOpt : ({});
   var isInverted = start > end;
   var n = options.step;
   var step;
@@ -48,17 +49,17 @@ function rangeWithOptions(start, end, options) {
   } else if (step === 0) {
     length = options.inclusive === true ? 1 : 0;
   } else {
-    var range = isInverted ? start - end | 0 : end - start | 0;
-    var range$1 = options.inclusive === true ? range + 1 | 0 : range;
-    length = Math.ceil(range$1 / PervasivesU.abs(step)) | 0;
+    var range$1 = isInverted ? start - end | 0 : end - start | 0;
+    var range$2 = options.inclusive === true ? range$1 + 1 | 0 : range$1;
+    length = Math.ceil(range$2 / PervasivesU.abs(step)) | 0;
   }
   return Core__Array.fromInitializer(length, (function (i) {
                 return start + Math.imul(i, step) | 0;
               }));
 }
 
-function range(start, end) {
-  return rangeWithOptions(start, end, {});
+function rangeWithOptions(start, end, options) {
+  return range(start, end, options);
 }
 
 function clamp(min, max, value) {

--- a/src/Core__Int.res
+++ b/src/Core__Int.res
@@ -8,27 +8,32 @@ let equal = (a: int, b: int) => a === b
 let compare = (a: int, b: int) =>
   a < b ? Core__Ordering.less : a > b ? Core__Ordering.greater : Core__Ordering.equal
 
-@send external toExponential: int => string = "toExponential"
-@send external toExponentialWithPrecision: (int, ~digits: int) => string = "toExponential"
+@send external toExponential: (int, ~digits: int=?) => string = "toExponential"
+@deprecated("Use `toExponential` instead") @send
+external toExponentialWithPrecision: (int, ~digits: int) => string = "toExponential"
 
-@send external toFixed: int => string = "toFixed"
-@send external toFixedWithPrecision: (int, ~digits: int) => string = "toFixed"
+@send external toFixed: (int, ~digits: int=?) => string = "toFixed"
+@deprecated("Use `toFixed` instead") @send
+external toFixedWithPrecision: (int, ~digits: int) => string = "toFixed"
 
-@send external toPrecision: int => string = "toPrecision"
-@send external toPrecisionWithPrecision: (int, ~digits: int) => string = "toPrecision"
+@send external toPrecision: (int, ~digits: int=?) => string = "toPrecision"
+@deprecated("Use `toPrecision` instead") @send
+external toPrecisionWithPrecision: (int, ~digits: int) => string = "toPrecision"
 
-@send external toString: int => string = "toString"
-@send external toStringWithRadix: (int, ~radix: int) => string = "toString"
+@send external toString: (int, ~radix: int=?) => string = "toString"
+@deprecated("Use `toString` instead") @send
+external toStringWithRadix: (int, ~radix: int) => string = "toString"
 @send external toLocaleString: int => string = "toLocaleString"
 
 external toFloat: int => float = "%identity"
 external fromFloat: float => int = "%intoffloat"
 
-let fromString = (~radix=?, x) => {
+let fromString = (x, ~radix=?) => {
   let maybeInt = switch radix {
-  | Some(radix) => Core__Float.parseIntWithRadix(x, ~radix)
+  | Some(radix) => Core__Float.parseInt(x, ~radix)
   | None => Core__Float.parseInt(x)
   }
+
   if Core__Float.isNaN(maybeInt) {
     None
   } else if maybeInt > Constants.maxValue->toFloat || maybeInt < Constants.minValue->toFloat {
@@ -42,7 +47,8 @@ let fromString = (~radix=?, x) => {
 external mod: (int, int) => int = "%modint"
 
 type rangeOptions = {step?: int, inclusive?: bool}
-let rangeWithOptions = (start, end, options) => {
+
+let range = (start, end, ~options: rangeOptions={}) => {
   let isInverted = start > end
 
   let step = switch options.step {
@@ -65,7 +71,8 @@ let rangeWithOptions = (start, end, options) => {
   Core__Array.fromInitializer(~length, i => start + i * step)
 }
 
-let range = (start, end) => rangeWithOptions(start, end, {})
+@deprecated("Use `range` instead") @send
+let rangeWithOptions = (start, end, options) => range(start, end, ~options)
 
 let clamp = (~min=?, ~max=?, value): int => {
   let value = switch max {

--- a/src/Core__Int.resi
+++ b/src/Core__Int.resi
@@ -61,20 +61,25 @@ let equal: (int, int) => bool
 let compare: (int, int) => Core__Ordering.t
 
 /**
-`toExponential(n)` return a `string` representing the given value in exponential
-notation.
-See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)
-on MDN.
+`toExponential(n, ~digits=?)` return a `string` representing the given value in
+exponential notation. `digits` specifies how many digits should appear after
+the decimal point. See [`Number.toExponential`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential)
 
 ## Examples
 
 ```rescript
 Int.toExponential(1000) // "1e+3"
 Int.toExponential(-1000) // "-1e+3"
+Int.toExponential(77, ~digits=2) // "7.70e+1"
+Int.toExponential(5678, ~digits=2) // "5.68e+3"
 ```
+
+## Exceptions
+
+- `RangeError`: If `digits` less than 0 or greater than 10.
 */
 @send
-external toExponential: int => string = "toExponential"
+external toExponential: (int, ~digits: int=?) => string = "toExponential"
 
 /**
 `toExponential(n, ~digits)` return a `string` representing the given value in
@@ -93,24 +98,31 @@ Int.toExponentialWithPrecision(5678, ~digits=2) // "5.68e+3"
 
 - `RangeError`: If `digits` less than 0 or greater than 10.
 */
+@deprecated("Use `toExponential` instead")
 @send
 external toExponentialWithPrecision: (int, ~digits: int) => string = "toExponential"
 
 /**
-`toFixed(n)` return a `string` representing the given value using fixed-point
-notation. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)
+`toFixed(n, ~digits=?)` return a `string` representing the given
+value using fixed-point notation. `digits` specifies how many digits should
+appear after the decimal point. See [`Number.toFixed`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed)
 on MDN.
-
 
 ## Examples
 
 ```rescript
 Int.toFixed(123456) // "123456.00"
 Int.toFixed(10) // "10.00"
+Int.toFixed(300, ~digits=4) // "300.0000"
+Int.toFixed(300, ~digits=1) // "300.0"
 ```
+
+## Exceptions
+
+- `RangeError`: If `digits` is less than 0 or larger than 100.
 */
 @send
-external toFixed: int => string = "toFixed"
+external toFixed: (int, ~digits: int=?) => string = "toFixed"
 
 /**
 `toFixedWithPrecision(n, ~digits)` return a `string` representing the given
@@ -129,23 +141,31 @@ Int.toFixedWithPrecision(300, ~digits=1) // "300.0"
 
 - `RangeError`: If `digits` is less than 0 or larger than 100.
 */
+@deprecated("Use `toFixed` instead")
 @send
 external toFixedWithPrecision: (int, ~digits: int) => string = "toFixed"
 
 /**
-`toPrecision(n)` return a `string` representing the giver value with precision.
-This function omits the argument that controls precision, so it behaves like
-`toString`. See `toPrecisionWithPrecision` to control precision. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.
+`toPrecision(n, ~digits=?)` return a `string` representing the giver value with
+precision. `digits` specifies the number of significant digits. See [`Number.toPrecision`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision) on MDN.
 
 ## Examples
 
 ```rescript
 Int.toPrecision(100) // "100"
 Int.toPrecision(1) // "1"
+Int.toPrecision(100, ~digits=2) // "1.0e+2"
+Int.toPrecision(1, ~digits=2) // "1.0"
 ```
+
+## Exceptions
+
+- `RangeError`: If `digits` is not between 1 and 100 (inclusive).
+Implementations are allowed to support larger and smaller values as well.
+ECMA-262 only requires a precision of up to 21 significant digits.
 */
 @send
-external toPrecision: int => string = "toPrecision"
+external toPrecision: (int, ~digits: int=?) => string = "toPrecision"
 
 /**
 `toPrecisionWithPrecision(n, ~digits)` return a `string` representing the giver value with
@@ -166,10 +186,12 @@ ECMA-262 only requires a precision of up to 21 significant digits.
 
 */
 @send
+@deprecated("Use `toPrecision` instead")
 external toPrecisionWithPrecision: (int, ~digits: int) => string = "toPrecision"
 
 /**
-`toString(n)` return a `string` representing the given value.
+`toString(n, ~radix=?)` return a `string` representing the given value.
+`~radix` specifies the radix base to use for the formatted number.
 See [`Number.toString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString)
 on MDN.
 
@@ -178,10 +200,17 @@ on MDN.
 ```rescript
 Int.toString(1000) // "1000"
 Int.toString(-1000) // "-1000"
+Int.toString(6, ~radix=2) // "110"
+Int.toString(373592855, ~radix=16) // "16449317"
+Int.toString(123456, ~radix=36) // "2n9c"
 ```
+
+## Exceptions
+
+`RangeError`: if `radix` is less than 2 or greater than 36.
 */
 @send
-external toString: int => string = "toString"
+external toString: (int, ~radix: int=?) => string = "toString"
 
 /**
 `toStringWithRadix(n, ~radix)` return a `string` representing the given value.
@@ -201,6 +230,7 @@ Int.toStringWithRadix(123456, ~radix=36) // "2n9c"
 
 `RangeError`: if `radix` is less than 2 or greater than 36.
 */
+@deprecated("Use `toString` instead")
 @send
 external toStringWithRadix: (int, ~radix: int) => string = "toString"
 
@@ -249,7 +279,7 @@ Int.fromFloat(0.9999) == 0
 external fromFloat: float => int = "%intoffloat"
 
 /**
-`fromString(~radix?, str)` return an `option<int>` representing the given value
+`fromString(str, ~radix=?)` return an `option<int>` representing the given value
 `str`. `~radix` specifies the radix base to use for the formatted number.
 
 ## Examples
@@ -257,10 +287,10 @@ external fromFloat: float => int = "%intoffloat"
 ```rescript
 Int.fromString("0") == Some(0)
 Int.fromString("NaN") == None
-Int.fromString(~radix=2, "6") == None
+Int.fromString("6", ~radix=2) == None
 ```
 */
-let fromString: (~radix: int=?, string) => option<int>
+let fromString: (string, ~radix: int=?) => option<int>
 
 /**
 `mod(n1, n2)` calculates the modulo (remainder after division) of two integers.
@@ -274,15 +304,27 @@ Int.mod(7, 4) == 3
 external mod: (int, int) => int = "%modint"
 
 /**
-`range(start, end)` returns an int array of the sequence of integers in the
+The options for `range`.
+*/
+type rangeOptions = {step?: int, inclusive?: bool}
+
+/**
+`range(start, end, ~options=?)` returns an int array of the sequence of integers in the
 range `[start, end)`. That is, including `start` but excluding `end`.
 
-If `start < end` the sequence will be increasing in steps of 1.
+If `step` is not set and `start < end`, the sequence will be increasing in steps of 1.
 
-If `start > end` the sequence will be decreasing in steps of -1.
+If `step` is not set and `start > end`, the sequence will be decreasing in steps of -1.
 
-This is equivalent to `rangeWithOptions` with `inclusive` set to `false` and
-`step` set to `1` if `start < end` and `-1` otherwise.
+If `step` is set, the sequence will increase or decrease by that amount for each
+step. If `start < end` and `step` is negative, or vice versa, an empty array is
+returned since the sequence would otherwise never reach or exceed the end value
+and hence be infinite. If `step` is `0` and `start !=` end, a `RangeError` is
+raised as the sequence would never reach or exceed the end value and hence be
+infinite.
+
+If `inclusive` is set to `true`, the sequence will include `end` if `step` is
+set such that the sequence includes it.
 
 ## Examples
 
@@ -290,14 +332,17 @@ This is equivalent to `rangeWithOptions` with `inclusive` set to `false` and
 Int.range(3, 6) == [3, 4, 5]
 Int.range(-3, -1) == [-3, -2]
 Int.range(3, 1) == [3, 2]
+Int.range(3, 7, ~options={step: 2}) == [3, 5]
+Int.range(3, 7, ~options={step: 2, inclusive: true}) == [3, 5, 7]
+Int.range(3, 6, ~options={step: -2}) // RangeError
+```
+
+## Exceptions
+
+- Raises `RangeError` if `step == 0 && start != end`.
 ```
 */
-let range: (int, int) => array<int>
-
-/**
-The options for `rangeWithOptions`.
-*/
-type rangeOptions = {step?: int, inclusive?: bool}
+let range: (int, int, ~options: rangeOptions=?) => array<int>
 
 /**
 `rangeWithOptions(start, end, options)` is like `range`, but with `step` and
@@ -325,6 +370,7 @@ Int.rangeWithOptions(3, 6, {step: -2}) // RangeError
 
 - Raises `RangeError` if `step == 0 && start != end`.
 */
+@deprecated("Use `range` instead")
 let rangeWithOptions: (int, int, rangeOptions) => array<int>
 
 /**

--- a/test/IntTests.mjs
+++ b/test/IntTests.mjs
@@ -31,7 +31,7 @@ Test.run([
         50
       ],
       "range - positive, increasing"
-    ], Core__Int.range(3, 6), eq, [
+    ], Core__Int.range(3, 6, undefined), eq, [
       3,
       4,
       5
@@ -45,7 +45,7 @@ Test.run([
         50
       ],
       "range - negative, increasing"
-    ], Core__Int.range(-3, -1), eq, [
+    ], Core__Int.range(-3, -1, undefined), eq, [
       -3,
       -2
     ]);
@@ -58,7 +58,7 @@ Test.run([
         51
       ],
       "range - cross-zero, incresing"
-    ], Core__Int.range(-1, 2), eq, [
+    ], Core__Int.range(-1, 2, undefined), eq, [
       -1,
       0,
       1
@@ -72,7 +72,7 @@ Test.run([
         42
       ],
       "range - start == end"
-    ], Core__Int.range(3, 3), eq, []);
+    ], Core__Int.range(3, 3, undefined), eq, []);
 
 Test.run([
       [
@@ -82,7 +82,7 @@ Test.run([
         50
       ],
       "range - positive, decreasing"
-    ], Core__Int.range(3, 1), eq, [
+    ], Core__Int.range(3, 1, undefined), eq, [
       3,
       2
     ]);
@@ -95,7 +95,7 @@ Test.run([
         50
       ],
       "range - negative, decreasing"
-    ], Core__Int.range(-1, -3), eq, [
+    ], Core__Int.range(-1, -3, undefined), eq, [
       -1,
       -2
     ]);
@@ -105,10 +105,10 @@ Test.run([
         "IntTests.res",
         21,
         13,
-        62
+        51
       ],
-      "rangeWithOptions - positive, increasing, step 2"
-    ], Core__Int.rangeWithOptions(3, 6, {
+      "range - positive, increasing, step 2"
+    ], Core__Int.range(3, 6, {
           step: 2
         }), eq, [
       3,
@@ -120,10 +120,10 @@ Test.run([
         "IntTests.res",
         27,
         13,
-        62
+        51
       ],
-      "rangeWithOptions + positive, increasing, step 2"
-    ], Core__Int.rangeWithOptions(3, 7, {
+      "range + positive, increasing, step 2"
+    ], Core__Int.range(3, 7, {
           step: 2
         }), eq, [
       3,
@@ -135,10 +135,10 @@ Test.run([
         "IntTests.res",
         33,
         13,
-        62
+        51
       ],
-      "rangeWithOptions + positive, increasing, step 2"
-    ], Core__Int.rangeWithOptions(3, 8, {
+      "range + positive, increasing, step 2"
+    ], Core__Int.range(3, 8, {
           step: 2
         }), eq, [
       3,
@@ -151,10 +151,10 @@ Test.run([
         "IntTests.res",
         39,
         13,
-        62
+        51
       ],
-      "rangeWithOptions - negative, increasing, step 2"
-    ], Core__Int.rangeWithOptions(-6, -3, {
+      "range - negative, increasing, step 2"
+    ], Core__Int.range(-6, -3, {
           step: 2
         }), eq, [
       -6,
@@ -166,11 +166,11 @@ Test.run([
         "IntTests.res",
         45,
         13,
-        62
+        51
       ],
-      "rangeWithOptions - positive, increasing, step 0"
+      "range - positive, increasing, step 0"
     ], $$catch(function () {
-          return Core__Int.rangeWithOptions(3, 6, {
+          return Core__Int.range(3, 6, {
                       step: 0
                     });
         }), eq, new RangeError("Incorrect range arguments"));
@@ -178,48 +178,48 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        51,
-        13,
-        54
+        50,
+        20,
+        50
       ],
-      "rangeWithOptions - start == end, step 0"
-    ], Core__Int.rangeWithOptions(3, 3, {
+      "range - start == end, step 0"
+    ], Core__Int.range(3, 3, {
           step: 0
         }), eq, []);
 
 Test.run([
       [
         "IntTests.res",
-        57,
+        52,
         13,
-        63
+        52
       ],
-      "rangeWithOptions + positive, increasing, step -1"
-    ], Core__Int.rangeWithOptions(3, 6, {
+      "range + positive, increasing, step -1"
+    ], Core__Int.range(3, 6, {
           step: -1
         }), eq, []);
 
 Test.run([
       [
         "IntTests.res",
-        63,
+        58,
         13,
-        62
+        51
       ],
-      "rangeWithOptions + positive, decreasing, step 1"
-    ], Core__Int.rangeWithOptions(6, 3, {
+      "range + positive, decreasing, step 1"
+    ], Core__Int.range(6, 3, {
           step: 1
         }), eq, []);
 
 Test.run([
       [
         "IntTests.res",
-        69,
+        64,
         13,
-        63
+        52
       ],
-      "rangeWithOptions + positive, decreasing, step -2"
-    ], Core__Int.rangeWithOptions(6, 3, {
+      "range + positive, decreasing, step -2"
+    ], Core__Int.range(6, 3, {
           step: -2
         }), eq, [
       6,
@@ -229,12 +229,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        75,
+        70,
         13,
-        63
+        52
       ],
-      "rangeWithOptions + positive, increasing, step -2"
-    ], Core__Int.rangeWithOptions(6, 2, {
+      "range + positive, increasing, step -2"
+    ], Core__Int.range(6, 2, {
           step: -2
         }), eq, [
       6,
@@ -244,12 +244,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        81,
+        76,
         13,
-        63
+        52
       ],
-      "rangeWithOptions + positive, increasing, step -2"
-    ], Core__Int.rangeWithOptions(6, 1, {
+      "range + positive, increasing, step -2"
+    ], Core__Int.range(6, 1, {
           step: -2
         }), eq, [
       6,
@@ -260,12 +260,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        87,
+        82,
         13,
-        63
+        52
       ],
-      "rangeWithOptions + negative, decreasing, step -2"
-    ], Core__Int.rangeWithOptions(-3, -6, {
+      "range + negative, decreasing, step -2"
+    ], Core__Int.range(-3, -6, {
           step: -2
         }), eq, [
       -3,
@@ -275,12 +275,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        93,
+        88,
         13,
-        73
+        62
       ],
-      "rangeWithOptions - positive, increasing, step 2, inclusive"
-    ], Core__Int.rangeWithOptions(3, 6, {
+      "range - positive, increasing, step 2, inclusive"
+    ], Core__Int.range(3, 6, {
           step: 2,
           inclusive: true
         }), eq, [
@@ -291,12 +291,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        99,
+        94,
         13,
-        73
+        62
       ],
-      "rangeWithOptions + positive, increasing, step 2, inclusive"
-    ], Core__Int.rangeWithOptions(3, 7, {
+      "range + positive, increasing, step 2, inclusive"
+    ], Core__Int.range(3, 7, {
           step: 2,
           inclusive: true
         }), eq, [
@@ -308,12 +308,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        105,
+        100,
         13,
-        73
+        62
       ],
-      "rangeWithOptions + positive, increasing, step 2, inclusive"
-    ], Core__Int.rangeWithOptions(3, 8, {
+      "range + positive, increasing, step 2, inclusive"
+    ], Core__Int.range(3, 8, {
           step: 2,
           inclusive: true
         }), eq, [
@@ -325,12 +325,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        111,
+        106,
         13,
-        73
+        62
       ],
-      "rangeWithOptions - negative, increasing, step 2, inclusive"
-    ], Core__Int.rangeWithOptions(-6, -3, {
+      "range - negative, increasing, step 2, inclusive"
+    ], Core__Int.range(-6, -3, {
           step: 2,
           inclusive: true
         }), eq, [
@@ -341,13 +341,13 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        117,
+        112,
         13,
-        73
+        62
       ],
-      "rangeWithOptions - positive, increasing, step 0, inclusive"
+      "range - positive, increasing, step 0, inclusive"
     ], $$catch(function () {
-          return Core__Int.rangeWithOptions(3, 6, {
+          return Core__Int.range(3, 6, {
                       step: 0,
                       inclusive: true
                     });
@@ -356,12 +356,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        123,
+        118,
         13,
-        65
+        54
       ],
-      "rangeWithOptions - start == end, step 0, inclusive"
-    ], Core__Int.rangeWithOptions(3, 3, {
+      "range - start == end, step 0, inclusive"
+    ], Core__Int.range(3, 3, {
           step: 0,
           inclusive: true
         }), eq, [3]);
@@ -369,12 +369,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        129,
+        124,
         13,
-        74
+        63
       ],
-      "rangeWithOptions + positive, increasing, step -1, inclusive"
-    ], Core__Int.rangeWithOptions(3, 6, {
+      "range + positive, increasing, step -1, inclusive"
+    ], Core__Int.range(3, 6, {
           step: -1,
           inclusive: true
         }), eq, []);
@@ -382,12 +382,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        135,
+        130,
         13,
-        73
+        62
       ],
-      "rangeWithOptions + positive, decreasing, step 1, inclusive"
-    ], Core__Int.rangeWithOptions(6, 3, {
+      "range + positive, decreasing, step 1, inclusive"
+    ], Core__Int.range(6, 3, {
           step: 1,
           inclusive: true
         }), eq, []);
@@ -395,12 +395,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        141,
+        136,
         13,
-        74
+        63
       ],
-      "rangeWithOptions + positive, decreasing, step -2, inclusive"
-    ], Core__Int.rangeWithOptions(6, 3, {
+      "range + positive, decreasing, step -2, inclusive"
+    ], Core__Int.range(6, 3, {
           step: -2,
           inclusive: true
         }), eq, [
@@ -411,12 +411,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        147,
+        142,
         13,
-        74
+        63
       ],
-      "rangeWithOptions + positive, increasing, step -2, inclusive"
-    ], Core__Int.rangeWithOptions(6, 2, {
+      "range + positive, increasing, step -2, inclusive"
+    ], Core__Int.range(6, 2, {
           step: -2,
           inclusive: true
         }), eq, [
@@ -428,12 +428,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        153,
+        148,
         13,
-        74
+        63
       ],
-      "rangeWithOptions + positive, increasing, step -2, inclusive"
-    ], Core__Int.rangeWithOptions(6, 1, {
+      "range + positive, increasing, step -2, inclusive"
+    ], Core__Int.range(6, 1, {
           step: -2,
           inclusive: true
         }), eq, [
@@ -445,12 +445,12 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        159,
+        154,
         13,
-        74
+        63
       ],
-      "rangeWithOptions + negative, decreasing, step -2, inclusive"
-    ], Core__Int.rangeWithOptions(-3, -6, {
+      "range + negative, decreasing, step -2, inclusive"
+    ], Core__Int.range(-3, -6, {
           step: -2,
           inclusive: true
         }), eq, [
@@ -461,7 +461,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        165,
+        160,
         20,
         27
       ],
@@ -471,7 +471,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        166,
+        161,
         20,
         35
       ],
@@ -481,7 +481,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        167,
+        162,
         20,
         35
       ],
@@ -491,7 +491,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        168,
+        163,
         20,
         35
       ],
@@ -501,7 +501,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        169,
+        164,
         20,
         35
       ],
@@ -511,7 +511,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        170,
+        165,
         20,
         42
       ],
@@ -521,7 +521,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        171,
+        166,
         20,
         42
       ],
@@ -531,7 +531,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        172,
+        167,
         20,
         42
       ],
@@ -541,7 +541,7 @@ Test.run([
 Test.run([
       [
         "IntTests.res",
-        173,
+        168,
         20,
         42
       ],

--- a/test/IntTests.res
+++ b/test/IntTests.res
@@ -18,146 +18,141 @@ Test.run(__POS_OF__("range - positive, decreasing"), Int.range(3, 1), eq, [3, 2]
 Test.run(__POS_OF__("range - negative, decreasing"), Int.range(-1, -3), eq, [-1, -2])
 
 Test.run(
-  __POS_OF__("rangeWithOptions - positive, increasing, step 2"),
-  Int.rangeWithOptions(3, 6, {step: 2}),
+  __POS_OF__("range - positive, increasing, step 2"),
+  Int.range(3, 6, ~options={step: 2}),
   eq,
   [3, 5],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step 2"),
-  Int.rangeWithOptions(3, 7, {step: 2}),
+  __POS_OF__("range + positive, increasing, step 2"),
+  Int.range(3, 7, ~options={step: 2}),
   eq,
   [3, 5],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step 2"),
-  Int.rangeWithOptions(3, 8, {step: 2}),
+  __POS_OF__("range + positive, increasing, step 2"),
+  Int.range(3, 8, ~options={step: 2}),
   eq,
   [3, 5, 7],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions - negative, increasing, step 2"),
-  Int.rangeWithOptions(-6, -3, {step: 2}),
+  __POS_OF__("range - negative, increasing, step 2"),
+  Int.range(-6, -3, ~options={step: 2}),
   eq,
   [-6, -4],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions - positive, increasing, step 0"),
-  catch(() => Int.rangeWithOptions(3, 6, {step: 0})),
+  __POS_OF__("range - positive, increasing, step 0"),
+  catch(() => Int.range(3, 6, ~options={step: 0})),
   eq,
   Error.RangeError.make("Incorrect range arguments"),
 )
+Test.run(__POS_OF__("range - start == end, step 0"), Int.range(3, 3, ~options={step: 0}), eq, [])
 Test.run(
-  __POS_OF__("rangeWithOptions - start == end, step 0"),
-  Int.rangeWithOptions(3, 3, {step: 0}),
+  __POS_OF__("range + positive, increasing, step -1"),
+  Int.range(3, 6, ~options={step: -1}),
   eq,
   [],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step -1"),
-  Int.rangeWithOptions(3, 6, {step: -1}),
+  __POS_OF__("range + positive, decreasing, step 1"),
+  Int.range(6, 3, ~options={step: 1}),
   eq,
   [],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, decreasing, step 1"),
-  Int.rangeWithOptions(6, 3, {step: 1}),
-  eq,
-  [],
-)
-Test.run(
-  __POS_OF__("rangeWithOptions + positive, decreasing, step -2"),
-  Int.rangeWithOptions(6, 3, {step: -2}),
+  __POS_OF__("range + positive, decreasing, step -2"),
+  Int.range(6, 3, ~options={step: -2}),
   eq,
   [6, 4],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step -2"),
-  Int.rangeWithOptions(6, 2, {step: -2}),
+  __POS_OF__("range + positive, increasing, step -2"),
+  Int.range(6, 2, ~options={step: -2}),
   eq,
   [6, 4],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step -2"),
-  Int.rangeWithOptions(6, 1, {step: -2}),
+  __POS_OF__("range + positive, increasing, step -2"),
+  Int.range(6, 1, ~options={step: -2}),
   eq,
   [6, 4, 2],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + negative, decreasing, step -2"),
-  Int.rangeWithOptions(-3, -6, {step: -2}),
+  __POS_OF__("range + negative, decreasing, step -2"),
+  Int.range(-3, -6, ~options={step: -2}),
   eq,
   [-3, -5],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions - positive, increasing, step 2, inclusive"),
-  Int.rangeWithOptions(3, 6, {step: 2, inclusive: true}),
+  __POS_OF__("range - positive, increasing, step 2, inclusive"),
+  Int.range(3, 6, ~options={step: 2, inclusive: true}),
   eq,
   [3, 5],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step 2, inclusive"),
-  Int.rangeWithOptions(3, 7, {step: 2, inclusive: true}),
+  __POS_OF__("range + positive, increasing, step 2, inclusive"),
+  Int.range(3, 7, ~options={step: 2, inclusive: true}),
   eq,
   [3, 5, 7],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step 2, inclusive"),
-  Int.rangeWithOptions(3, 8, {step: 2, inclusive: true}),
+  __POS_OF__("range + positive, increasing, step 2, inclusive"),
+  Int.range(3, 8, ~options={step: 2, inclusive: true}),
   eq,
   [3, 5, 7],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions - negative, increasing, step 2, inclusive"),
-  Int.rangeWithOptions(-6, -3, {step: 2, inclusive: true}),
+  __POS_OF__("range - negative, increasing, step 2, inclusive"),
+  Int.range(-6, -3, ~options={step: 2, inclusive: true}),
   eq,
   [-6, -4],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions - positive, increasing, step 0, inclusive"),
-  catch(() => Int.rangeWithOptions(3, 6, {step: 0, inclusive: true})),
+  __POS_OF__("range - positive, increasing, step 0, inclusive"),
+  catch(() => Int.range(3, 6, ~options={step: 0, inclusive: true})),
   eq,
   Error.RangeError.make("Incorrect range arguments"),
 )
 Test.run(
-  __POS_OF__("rangeWithOptions - start == end, step 0, inclusive"),
-  Int.rangeWithOptions(3, 3, {step: 0, inclusive: true}),
+  __POS_OF__("range - start == end, step 0, inclusive"),
+  Int.range(3, 3, ~options={step: 0, inclusive: true}),
   eq,
   [3],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step -1, inclusive"),
-  Int.rangeWithOptions(3, 6, {step: -1, inclusive: true}),
+  __POS_OF__("range + positive, increasing, step -1, inclusive"),
+  Int.range(3, 6, ~options={step: -1, inclusive: true}),
   eq,
   [],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, decreasing, step 1, inclusive"),
-  Int.rangeWithOptions(6, 3, {step: 1, inclusive: true}),
+  __POS_OF__("range + positive, decreasing, step 1, inclusive"),
+  Int.range(6, 3, ~options={step: 1, inclusive: true}),
   eq,
   [],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, decreasing, step -2, inclusive"),
-  Int.rangeWithOptions(6, 3, {step: -2, inclusive: true}),
+  __POS_OF__("range + positive, decreasing, step -2, inclusive"),
+  Int.range(6, 3, ~options={step: -2, inclusive: true}),
   eq,
   [6, 4],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step -2, inclusive"),
-  Int.rangeWithOptions(6, 2, {step: -2, inclusive: true}),
+  __POS_OF__("range + positive, increasing, step -2, inclusive"),
+  Int.range(6, 2, ~options={step: -2, inclusive: true}),
   eq,
   [6, 4, 2],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + positive, increasing, step -2, inclusive"),
-  Int.rangeWithOptions(6, 1, {step: -2, inclusive: true}),
+  __POS_OF__("range + positive, increasing, step -2, inclusive"),
+  Int.range(6, 1, ~options={step: -2, inclusive: true}),
   eq,
   [6, 4, 2],
 )
 Test.run(
-  __POS_OF__("rangeWithOptions + negative, decreasing, step -2, inclusive"),
-  Int.rangeWithOptions(-3, -6, {step: -2, inclusive: true}),
+  __POS_OF__("range + negative, decreasing, step -2, inclusive"),
+  Int.range(-3, -6, ~options={step: -2, inclusive: true}),
   eq,
   [-3, -5],
 )

--- a/test/TempTests.mjs
+++ b/test/TempTests.mjs
@@ -89,7 +89,7 @@ console.log((10.2).toFixed(2));
 
 console.log((10).toFixed(2));
 
-console.log(Core__Int.fromString(undefined, "0"));
+console.log(Core__Int.fromString("0", undefined));
 
 console.log(Core__Float.fromString("0.1"));
 
@@ -300,15 +300,15 @@ console.log({
 
 var Bugfix = {};
 
-console.log(Core__Int.fromString(undefined, "1231231"));
+console.log(Core__Int.fromString("1231231", undefined));
 
-console.log(Core__Int.fromString(undefined, "12.22"));
+console.log(Core__Int.fromString("12.22", undefined));
 
-console.log(Core__Int.fromString(undefined, "99999999999999999"));
+console.log(Core__Int.fromString("99999999999999999", undefined));
 
-console.log(Core__Int.fromString(undefined, "99999999999999999"));
+console.log(Core__Int.fromString("99999999999999999", undefined));
 
-console.log(Core__Int.fromString(2, "010101"));
+console.log(Core__Int.fromString("010101", 2));
 
 var _collator = IntlTests._collator;
 

--- a/test/TempTests.res
+++ b/test/TempTests.res
@@ -38,8 +38,8 @@ let f = () => {
 Console.info("")
 Console.info("Float/Int")
 Console.info("---")
-Console.log(10.2->Float.toFixedWithPrecision(~digits=2))
-Console.log(10->Int.toFixedWithPrecision(~digits=2))
+Console.log(10.2->Float.toFixed(~digits=2))
+Console.log(10->Int.toFixed(~digits=2))
 Console.log("0"->Int.fromString)
 Console.log("0.1"->Float.fromString)
 

--- a/test/TypedArrayTests.mjs
+++ b/test/TypedArrayTests.mjs
@@ -49,7 +49,7 @@ function assertWillThrow(message, f) {
 }
 
 function areSame(x, y) {
-  return x.toString() === y.toString();
+  return x.toString(undefined) === y.toString(undefined);
 }
 
 assertTrue("fromArray", (function () {


### PR DESCRIPTION
See #206.

Note that currently this still generates code like `x.toString(undefined)` instead of `x.toString()` if no options are passed, but this will be fixed with 11.1 rc.8, see https://github.com/rescript-lang/rescript-compiler/pull/6716.