### PR TITLE
Fix docstrings for `Int` and `Float`

### DIFF
--- a/src/Core__Float.resi
+++ b/src/Core__Float.resi
@@ -225,7 +225,6 @@ Float.toExponential(5678.0, ~digits=2) // "5.68e+3"
 ## Exceptions
 
 - `RangeError`: If `digits` less than 0 or greater than 10.
-```
 */
 @send
 external toExponential: (float, ~digits: int=?) => string = "toExponential"

--- a/src/Core__Int.resi
+++ b/src/Core__Int.resi
@@ -340,7 +340,6 @@ Int.range(3, 6, ~options={step: -2}) // RangeError
 ## Exceptions
 
 - Raises `RangeError` if `step == 0 && start != end`.
-```
 */
 let range: (int, int, ~options: rangeOptions=?) => array<int>
 


### PR DESCRIPTION
Invalid Markdown broke the deployment https://github.com/rescript-association/rescript-lang.org/pull/852