### PR TITLE
:bug: - Fix binding of Array.get, to make sure it boxes options

### DIFF
--- a/src/Core__Array.mjs
+++ b/src/Core__Array.mjs
@@ -99,6 +99,13 @@ function reduceRightWithIndex(arr, init, f) {
   return arr.reduceRight(f, init);
 }
 
+function get(arr, i) {
+  if (i >= 0 && i < arr.length) {
+    return Caml_option.some(arr[i]);
+  }
+  
+}
+
 function findIndexOpt(array, finder) {
   var index = array.findIndex(finder);
   if (index !== -1) {
@@ -166,7 +173,7 @@ function findMap(arr, f) {
 }
 
 function last(a) {
-  return a[a.length - 1 | 0];
+  return get(a, a.length - 1 | 0);
 }
 
 export {
@@ -180,6 +187,7 @@ export {
   reduceWithIndex ,
   reduceRight ,
   reduceRightWithIndex ,
+  get ,
   findIndexOpt ,
   filterMap ,
   keepSome ,

--- a/src/Core__Array.res
+++ b/src/Core__Array.res
@@ -184,7 +184,13 @@ let reduceRightWithIndex = (arr, init, f) => reduceRightWithIndex(arr, f, init)
 @send external some: (array<'a>, 'a => bool) => bool = "some"
 @send external someWithIndex: (array<'a>, ('a, int) => bool) => bool = "some"
 
-@get_index external get: (array<'a>, int) => option<'a> = ""
+let get = (arr, i) =>
+  if i >= 0 && i < length(arr) {
+    Some(getUnsafe(arr, i))
+  } else {
+    None
+  }
+
 @set_index external set: (array<'a>, int, 'a) => unit = ""
 
 @get_index external getSymbol: (array<'a>, Core__Symbol.t) => option<'b> = ""

--- a/src/Core__Array.resi
+++ b/src/Core__Array.resi
@@ -822,8 +822,7 @@ array->Array.get(0) == Some("Hello") // true
 array->Array.get(3) == None // true
 ```
 */
-@get_index
-external get: (array<'a>, int) => option<'a> = ""
+let get: (array<'a>, int) => option<'a>
 
 /**
 `set(array, index, item)` sets the provided `item` at `index` of `array`.


### PR DESCRIPTION
This can cause runtime crashes when the individual members are options. When you are using `Option.getExn` after an `Array.get` to get the value if you know the array is in bounds, it will crash if the item in the array an option type and is `None` for the element. In normal cases you would use `Array.getUnsafe` for this, but in more complex scenarios this can happen. The types are actually incorrect and it can lead to crashes where you wouldn't expect it.