### PR TITLE
Add `Math.Int.ceil`

### DIFF
--- a/src/Core__Math.mjs
+++ b/src/Core__Math.mjs
@@ -7,6 +7,10 @@ function floor(f) {
   return Math.floor(f) | 0;
 }
 
+function ceil(f) {
+  return Math.ceil(f) | 0;
+}
+
 function random(min, max) {
   var f = Math.random() * (max - min | 0);
   return (Math.floor(f) | 0) + min | 0;
@@ -14,6 +18,7 @@ function random(min, max) {
 
 var Int = {
   floor: floor,
+  ceil: ceil,
   random: random
 };
 

--- a/src/Core__Math.res
+++ b/src/Core__Math.res
@@ -57,6 +57,7 @@ module Int = {
   @val external pow: (int, ~exp: int) => int = "Math.pow"
   @val external sign: int => int = "Math.sign"
   let floor: float => int = f => f->floor->Core__Float.toInt
+  let ceil: float => int = f => f->ceil->Core__Float.toInt
   let random: (int, int) => int = (min, max) =>
     floor(random() *. Core__Int.toFloat(max - min)) + min
 }

--- a/src/Core__Math.resi
+++ b/src/Core__Math.resi
@@ -296,6 +296,21 @@ module Int: {
   let floor: float => int
 
   /**
+  ceil(v) returns the smallest `int` greater than or equal to the argument;
+  See [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor)
+  on MDN.
+
+  ## Examples
+
+  ```rescript
+  Math.Int.ceil(3.7) == 4
+  Math.Int.ceil(3.0) == 3
+  Math.Int.ceil(-3.1) == -3
+  ```
+  */
+  let ceil: float => int
+
+  /**
   `random(minVal, maxVal)` returns a random integer number in the half-closed interval [minVal, maxVal).
    See [`Math.random`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random)
   on MDN.

--- a/src/Core__Math.resi
+++ b/src/Core__Math.resi
@@ -279,7 +279,6 @@ module Int: {
 
   /**
   floor(v) returns the largest `int` less than or equal to the argument; 
-  the result is pinned to the range of the `int` data type: -2147483648 to 2147483647. 
   See [`Math.floor`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor)
   on MDN.
 
@@ -289,8 +288,6 @@ module Int: {
   Math.Int.floor(3.7) == 3
   Math.Int.floor(3.0) == 3
   Math.Int.floor(-3.1) == -4
-  Math.Int.floor(-1.0e15) == -2147483648
-  Math.Int.floor(1.0e15) == 2147483647
   ```
   */
   let floor: float => int


### PR DESCRIPTION
Also fixes the documentation of `Math.Int.floor` since it's incorrect