### PR TITLE
Correct comparison operator in Array.every() method

### DIFF
--- a/src/Core__Array.resi
+++ b/src/Core__Array.resi
@@ -528,7 +528,7 @@ See [`Array.every`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 ```rescript
 let array = [1, 2, 3, 4]
 
-Console.log(array->Array.every(num => num > 4)) // true
+Console.log(array->Array.every(num => num <= 4)) // true
 Console.log(array->Array.every(num => num === 1)) // false
 ```
 */


### PR DESCRIPTION
Fix typo in Array.every() comparison operator
Yay, my first contribution
```rescript
let array = [1, 2, 3, 4]

//before
Console.log(array->Array.every(num => num > 4)) // true

//after
Console.log(array->Array.every(num => num <= 4)) // true
```