### PR TITLE
Remove leftover top-level t<'a>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - BREAKING: Fixes the type of `RegExp.Result.t` to be `array<option<string>>` instead of `array<string>`. https://github.com/rescript-association/rescript-core/pull/234.
 - Fix type of `Nullable.t` which was not untagged in the implementation. https://github.com/rescript-association/rescript-core/pull/235
+- Remove leftover top-level t<'a>. https://github.com/rescript-association/rescript-core/pull/236
 
 ## 1.4.0
 

--- a/src/RescriptCore.res
+++ b/src/RescriptCore.res
@@ -94,7 +94,6 @@ async function main() {
 */
 external import: 'a => promise<'a> = "#import"
 
-type t<'a> = Js.t<'a>
 module MapperRt = Js.MapperRt
 module Internal = Js.Internal
 module Re = Core__RegExp // needed for the %re sugar


### PR DESCRIPTION
I don't think there is any use for this, must be a leftover.
And `Js.t<'a>` has been obsolete for quite some time.