### PR TITLE
Remove aliases for runtime modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next version
 
+## 1.5.2
+
+- Remove aliases for runtime modules (`MapperRt`, `Internal`) and `Re`. https://github.com/rescript-association/rescript-core/pull/237
+
 ## 1.5.1
 
 - Remove leftover top-level t<'a>. https://github.com/rescript-association/rescript-core/pull/236

--- a/src/RescriptCore.mjs
+++ b/src/RescriptCore.mjs
@@ -82,12 +82,6 @@ var $$BigUint64Array;
 
 var $$Intl;
 
-var MapperRt;
-
-var Internal;
-
-var Re;
-
 var Exn;
 
 var $$Option;
@@ -139,9 +133,6 @@ export {
   $$BigInt64Array ,
   $$BigUint64Array ,
   $$Intl ,
-  MapperRt ,
-  Internal ,
-  Re ,
   Exn ,
   $$Option ,
   List ,

--- a/src/RescriptCore.res
+++ b/src/RescriptCore.res
@@ -94,9 +94,6 @@ async function main() {
 */
 external import: 'a => promise<'a> = "#import"
 
-module MapperRt = Js.MapperRt
-module Internal = Js.Internal
-module Re = Core__RegExp // needed for the %re sugar
 module Exn = Js.Exn
 module Option = Core__Option
 module List = Core__List


### PR DESCRIPTION
These should not be part of Core.

Currently, the compiler is using `Js.MapperRt`, not `RescriptCore.MapperRt`, etc.
And in the future, such things should go into `runtime`, not into Core, see https://github.com/rescript-lang/rescript-compiler/issues/6836.